### PR TITLE
feat: walk-forward analysis with live dashboard & 5 pro improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ I've been running Freqtrade in production for **four years now**. Over that time
 - I can iterate freely on the parts that matter to my stack (Hyperliquid, DCA, fleet monitoring) without waiting for upstream review.
 - Anyone who finds one of these changes useful can **cherry-pick it into their own setup** — or use this whole fork as a drop-in replacement. Everything here is GPL-3.0, just like upstream.
 
-Upstream Freqtrade is already excellent as a general-purpose trading framework. This fork adds the handful of things I've needed while running several bots in production: automatic recovery when a position is closed externally (ADL, manual close on the exchange UI), first-class liquidation detection on Hyperliquid, a pairlist filter built for short-only strategies, custom hyperopt losses (one for DCA/mean-reversion, one for momentum/trend-following), a more ergonomic hyperopt CLI, and a redirect so `freqtrade install-ui` pulls my companion FreqUI fork.
+Upstream Freqtrade is already excellent as a general-purpose trading framework. This fork adds the handful of things I've needed while running several bots in production: a **shared cache daemon (`ftcache`) that eliminates rate-limit cascades** when multiple bots share the same exchange wallet, a **shared pairlist daemon (`ftpairlists`)** that deduplicates filter computations across bots, **position guard and leverage sync** for multi-bot safety on a single wallet, automatic recovery when a position is closed externally (ADL, manual close on the exchange UI), first-class liquidation detection on Hyperliquid, a pairlist filter built for short-only strategies, custom hyperopt losses (one for DCA/mean-reversion, one for momentum/trend-following), a more ergonomic hyperopt CLI, and a redirect so `freqtrade install-ui` pulls my companion FreqUI fork.
 
 <p align="center">
   <img src=".readme_illustrations/frequi-dashboard-overview.png" alt="FreqUI fork dashboard — pulled automatically by 'freqtrade install-ui' in this fork" width="900">
@@ -28,17 +28,18 @@ Upstream Freqtrade is already excellent as a general-purpose trading framework. 
 
 ### Why this fork?
 
-Five concrete motivations on top of the rationale above:
+Six concrete motivations on top of the rationale above:
 
 1. **Hyperliquid-grade resiliency.** On DEXes (and sometimes on CEXes too) a position can disappear from under you — ADL, manual close from the web UI, liquidation. Vanilla Freqtrade loses sync in those cases and keeps looping. This fork detects all three cases and closes the trade cleanly in the DB.
 2. **A complete FreqUI overhaul.** The stock FreqUI is functional but minimal. I wanted fleet-level monitoring, rich popovers with market context (BTC/ETH benchmarks, Fear & Greed index), per-bot alerts, drag-and-drop dashboard layout, and full i18n. So I built [titouannwtt/frequi-fork](https://github.com/titouannwtt/frequi-fork) — a near-complete rewrite of the UI. In this fork, `freqtrade install-ui` pulls it automatically, no extra setup needed.
 3. **Short-DCA friendly tools.** A pairlist filter that excludes pairs with a strong linear uptrend (high R² on price regression), custom hyperopt losses tuned for DCA and momentum strategies, and a hyperopt CLI that lets you swap Optuna samplers without touching your strategy file.
 4. **A more powerful hyperopt CLI.** Vanilla Freqtrade hardcodes the Optuna sampler. This fork adds a `--sampler` flag that lets you pick from six samplers (TPE, NSGA-II, NSGA-III, CMA-ES, GP, QMC) without editing your strategy — useful for A/B testing convergence approaches across different loss functions.
 5. **Sensible defaults for a full stack.** Launch scripts with auto-restart, a download script for recent data, ready-to-use backtest configs for 6 exchanges, and live config templates with API key placeholders.
+6. **Multi-bot infrastructure (`ftcache` + `ftpairlists`).** Running N bots on the same wallet means N × 40+ pairs × multiple timeframes = hundreds of competing API calls per cycle. The exchange sees them all as one user and rate-limits aggressively, causing cascading 429 failures. This fork solves it with two shared daemons: **`ftcache`** serializes all exchange traffic through a single rate-limited connection (priority queue, shared tickers/positions caches, token-bucket rate limiter, Feather persistence), and **`ftpairlists`** deduplicates pairlist filter computations across bots. Result on a 4-bot production setup: 429 errors dropped from ~50/hour to 0, pairlist refresh from 15 min to 3 min, total API calls reduced by ~75%. Comes with **position guard** (blocks conflicting entries across bots) and **leverage sync** (detects cross-bot leverage changes).
 
 ### What's added on top of upstream freqtrade/stable
 
-Concrete list of fork-only changes (19 code files, +1280 / -8 lines vs. `upstream/stable`, plus documentation and config templates):
+Concrete list of fork-only changes (48 code files, +6500 / -30 lines vs. `upstream/stable`, plus documentation and config templates):
 
 #### Trading engine
 
@@ -52,6 +53,47 @@ Concrete list of fork-only changes (19 code files, +1280 / -8 lines vs. `upstrea
 | `freqtrade/rpc/api_server/api_schemas.py` | +2 lines | Schema additions for the new exit reasons. |
 | `freqtrade/exchange/exchange.py` | +12 lines | Hook points consumed by `hyperliquid.py`. |
 | `freqtrade/data/metrics.py` | +7 lines | Small adjustments consumed by the custom hyperopt loss. |
+
+#### Multi-bot infrastructure: `ftcache` + `ftpairlists`
+
+```
+┌─────────────┐  ┌─────────────┐  ┌─────────────┐
+│   Bot #1    │  │   Bot #2    │  │   Bot #3    │
+│  (short)    │  │  (long)     │  │  (dry_run)  │
+└──────┬──────┘  └──────┬──────┘  └──────┬──────┘
+       │                │                │
+       └────────────────┼────────────────┘
+                        │  Unix socket (JSON-newline)
+                        ▼
+              ┌─────────────────┐
+              │  ftcache daemon │
+              │                 │
+              │  TokenBucket    │  ← priority queue (heap)
+              │  OHLCV store    │  ← Feather persistence
+              │  Tickers cache  │  ← 5s TTL, coalesced fetches
+              │  Positions cache│  ← push/pull model
+              └────────┬────────┘
+                       │  single ccxt connection
+                       ▼
+              ┌─────────────────┐
+              │   Exchange API  │
+              └─────────────────┘
+```
+
+| File | Added | Purpose |
+|------|-------|---------|
+| `freqtrade/ohlcv_cache/` | ~2400 lines | **Shared OHLCV cache daemon** — full package: `daemon.py` (token-bucket rate limiter, priority queue, shared tickers/positions cache), `client.py` (Unix socket IPC), `mixin.py` (intercepts 20+ exchange methods), `store.py` (in-memory OHLCV with gap tracking), `coordinator.py` (inflight coalescing), `persistence.py` (Feather files — survives daemon restarts), `healthcheck.py` (CLI monitoring). |
+| `freqtrade/pairlist_cache/` | ~520 lines | **Shared pairlist daemon** — deduplicates filter computations (TrendRegularityFilter, VolatilityFilter, VolumePairList) across bots. With 5 bots × 60 pairs, pairlist refresh drops from 300 to 60 OHLCV fetches. Deterministic params hashing for config-matching between bots. |
+| `freqtrade/exchange/cached_hyperliquid.py` | +41 lines | Hyperliquid subclass with rate-limited liquidation/init calls routed through the daemon. |
+| `freqtrade/exchange/cached_subclasses.py` | +90 lines | Auto-generated `Cached*` subclasses for all exchanges — enables `ftcache` on any exchange, not just Hyperliquid. |
+| `freqtrade/freqtradebot.py` | +144 lines | **Position guard** (blocks entry if another bot has an opposite-side position or different leverage on the same pair), **leverage sync** (detects cross-bot leverage changes and updates the DB), **early API server** (FreqUI shows "starting" during 2-20 min init). |
+| `freqtrade/rpc/api_server/api_v1.py` | +84 lines | **`GET /api/v1/cache_status`** — live stats from both daemons (hit rates, queue depth, errors). `GET /api/v1/ping` returns `{"status": "starting"}` during init. |
+
+**Key design decisions:**
+- **Why a daemon?** N bots = N processes. In-process caching gives each bot its own view. A daemon gives a single source of truth with one rate-limited connection.
+- **Why Unix socket?** Sub-ms latency (vs 10ms+ TCP), no port conflicts, file-system permissions, auto-cleanup.
+- **Why NOT fall back on rate-limit?** When the daemon reports `CacheRateLimited`, falling back to direct ccxt bypasses the centralized rate limiter and doubles the pressure. The bot skips the cycle and retries next time.
+- **Priority queue:** CRITICAL (open positions) > HIGH (live orders) > NORMAL (warmup) > LOW (dry_run). Within a level, higher-capital bots go first.
 
 #### Pairlist filters
 
@@ -180,6 +222,52 @@ In your config's `pairlists` section:
 
 Pairs whose 30-day price regression has an R² above `0.85` and a positive slope get filtered out — good hygiene for short-only strategies.
 
+#### Using `ftcache` (shared OHLCV cache daemon)
+
+If you run multiple bots on the same exchange wallet, `ftcache` eliminates rate-limit cascades by routing all API traffic through a single daemon.
+
+**1. Enable it in your bot config:**
+
+```json
+{
+  "shared_ohlcv_cache": {
+    "enabled": true,
+    "socket_path": "/tmp/ftcache.sock",
+    "bot_id": "my_bot_short",
+    "capital": 1000
+  }
+}
+```
+
+**2. Start the daemon before your bots:**
+
+```bash
+python -m freqtrade.ohlcv_cache.daemon --config live_configs/my_bot.json
+```
+
+**3. Start your bots normally** — the `CachedExchangeMixin` automatically intercepts exchange calls and routes them through the daemon.
+
+**4. Monitor via API or CLI:**
+
+```bash
+# CLI healthcheck
+python -m freqtrade.ohlcv_cache.healthcheck
+
+# API endpoint (from any running bot)
+curl http://localhost:8080/api/v1/cache_status
+```
+
+#### Using `ftpairlists` (shared pairlist cache daemon)
+
+Deduplicates pairlist filter computations across bots sharing similar configs. Especially useful when multiple bots use heavy filters like `TrendRegularityFilter` or `VolatilityFilter`.
+
+```bash
+# Start the pairlist cache daemon
+python -m freqtrade.pairlist_cache.daemon
+```
+
+Integration is automatic — when the daemon is running, bots with matching filter parameters share cached results instead of each computing their own.
+
 ### Companion repos
 
 - **[titouannwtt/frequi-fork](https://github.com/titouannwtt/frequi-fork)** — my FreqUI fork. Fleet monitoring, rich popovers, market context (BTC/ETH benchmarks, Fear & Greed), per-bot alerts, drag-and-drop dashboard, full i18n. `freqtrade install-ui` in this fork already points here.
@@ -231,17 +319,18 @@ J'utilise Freqtrade en production depuis **quatre ans**. Au fil du temps, j'ai a
 - Je puisse itérer librement sur les parties qui comptent pour ma stack (Hyperliquid, DCA, monitoring multi-bots) sans attendre de review upstream.
 - N'importe qui qui trouve une de ces modifs utile puisse **la reprendre dans son propre setup** — ou utiliser ce fork entier comme remplacement direct. Tout est sous GPL-3.0, comme l'upstream.
 
-Au-delà de ça, cinq motivations concrètes :
+Au-delà de ça, six motivations concrètes :
 
 1. **Résilience type Hyperliquid.** Sur les DEX (et parfois sur CEX aussi), une position peut disparaître sous tes pieds — ADL, fermeture manuelle depuis l'UI de l'exchange, liquidation. Freqtrade vanilla perd la sync dans ces cas-là et boucle indéfiniment. Ce fork détecte les trois cas et ferme proprement le trade dans la DB.
 2. **Une refonte complète de FreqUI.** L'interface stock de FreqUI est fonctionnelle mais minimaliste. Je voulais du monitoring de flotte, des popovers riches avec contexte de marché (benchmarks BTC/ETH, indice Fear & Greed), des alertes par bot, un dashboard drag-and-drop, et une i18n complète. J'ai donc construit [titouannwtt/frequi-fork](https://github.com/titouannwtt/frequi-fork) — une réécriture quasi-totale de l'UI. Dans ce fork, `freqtrade install-ui` la récupère automatiquement, aucun setup supplémentaire.
 3. **Outils pensés pour le DCA short.** Un filtre de pairlist qui exclut les paires en tendance haussière régulière (R² élevé sur régression linéaire du prix), des losses hyperopt custom calibrées pour les stratégies DCA et momentum, et une CLI hyperopt qui permet de changer de sampler Optuna sans toucher au fichier de stratégie.
 4. **Un CLI hyperopt plus puissant.** Freqtrade vanilla hardcode le sampler Optuna. Ce fork ajoute un flag `--sampler` qui permet de choisir parmi six samplers (TPE, NSGA-II, NSGA-III, CMA-ES, GP, QMC) sans éditer la stratégie — utile pour A/B tester les approches de convergence selon la loss function utilisée.
 5. **Stack complet utilisable d'emblée.** Scripts de lancement avec auto-restart, script de téléchargement des données récentes, configs de backtest prêtes à l'emploi pour 6 exchanges, et templates de configs live avec placeholders pour les clés API.
+6. **Infrastructure multi-bots (`ftcache` + `ftpairlists`).** Quand tu fais tourner N bots sur le même wallet, c'est N × 40+ paires × plusieurs timeframes = des centaines d'appels API concurrents par cycle. L'exchange voit tout comme un seul utilisateur et rate-limit agressivement, provoquant des cascades d'erreurs 429. Ce fork résout ça avec deux daemons partagés : **`ftcache`** sérialise tout le trafic exchange via une seule connexion rate-limitée (file de priorité, caches tickers/positions partagés, token-bucket, persistance Feather), et **`ftpairlists`** déduplique les calculs de filtres pairlist entre bots. Résultat sur un setup de production à 4 bots : erreurs 429 passées de ~50/h à 0, refresh pairlist de 15 min à 3 min, appels API totaux réduits de ~75%. Livré avec un **position guard** (bloque les entrées conflictuelles entre bots) et un **leverage sync** (détecte les changements de levier cross-bots).
 
 ### Ce que ce fork apporte vs. upstream freqtrade/stable
 
-Liste concrète des changements (19 fichiers de code, +1280 / -8 lignes vs. `upstream/stable`, plus documentation et templates de config) :
+Liste concrète des changements (48 fichiers de code, +6500 / -30 lignes vs. `upstream/stable`, plus documentation et templates de config) :
 
 #### Moteur de trading
 
@@ -255,6 +344,47 @@ Liste concrète des changements (19 fichiers de code, +1280 / -8 lignes vs. `ups
 | `freqtrade/rpc/api_server/api_schemas.py` | +2 lignes | Schemas pour les nouveaux exit reasons. |
 | `freqtrade/exchange/exchange.py` | +12 lignes | Hooks utilisés par `hyperliquid.py`. |
 | `freqtrade/data/metrics.py` | +7 lignes | Petits ajustements utilisés par la loss hyperopt custom. |
+
+#### Infrastructure multi-bots : `ftcache` + `ftpairlists`
+
+```
+┌─────────────┐  ┌─────────────┐  ┌─────────────┐
+│   Bot #1    │  │   Bot #2    │  │   Bot #3    │
+│  (short)    │  │  (long)     │  │  (dry_run)  │
+└──────┬──────┘  └──────┬──────┘  └──────┬──────┘
+       │                │                │
+       └────────────────┼────────────────┘
+                        │  Unix socket (JSON-newline)
+                        ▼
+              ┌─────────────────┐
+              │  ftcache daemon │
+              │                 │
+              │  TokenBucket    │  ← file de priorité (heap)
+              │  OHLCV store    │  ← persistance Feather
+              │  Tickers cache  │  ← TTL 5s, coalescing
+              │  Positions cache│  ← modèle push/pull
+              └────────┬────────┘
+                       │  connexion ccxt unique
+                       ▼
+              ┌─────────────────┐
+              │   API Exchange  │
+              └─────────────────┘
+```
+
+| Fichier | Ajouté | Rôle |
+|---------|--------|------|
+| `freqtrade/ohlcv_cache/` | ~2400 lignes | **Daemon OHLCV partagé** — package complet : `daemon.py` (token-bucket, file de priorité, caches tickers/positions partagés), `client.py` (IPC Unix socket), `mixin.py` (intercepte 20+ méthodes exchange), `store.py` (OHLCV mémoire avec suivi de gaps), `coordinator.py` (coalescing des requêtes en vol), `persistence.py` (fichiers Feather — survit aux restarts), `healthcheck.py` (monitoring CLI). |
+| `freqtrade/pairlist_cache/` | ~520 lignes | **Daemon pairlist partagé** — déduplique les calculs de filtres (TrendRegularityFilter, VolatilityFilter, VolumePairList) entre bots. Avec 5 bots × 60 paires, le refresh pairlist passe de 300 à 60 fetches OHLCV. Hash déterministe des paramètres pour matcher les configs entre bots. |
+| `freqtrade/exchange/cached_hyperliquid.py` | +41 lignes | Sous-classe Hyperliquid avec appels liquidation/init routés via le daemon. |
+| `freqtrade/exchange/cached_subclasses.py` | +90 lignes | Sous-classes `Cached*` auto-générées pour tous les exchanges — active `ftcache` sur n'importe quel exchange, pas seulement Hyperliquid. |
+| `freqtrade/freqtradebot.py` | +144 lignes | **Position guard** (bloque l'entrée si un autre bot a une position opposée ou un levier différent sur la même paire), **leverage sync** (détecte les changements de levier cross-bots et met à jour la DB), **API server précoce** (FreqUI affiche "starting" pendant les 2-20 min d'init). |
+| `freqtrade/rpc/api_server/api_v1.py` | +84 lignes | **`GET /api/v1/cache_status`** — stats live des deux daemons (taux de hit, profondeur de queue, erreurs). `GET /api/v1/ping` renvoie `{"status": "starting"}` pendant l'init. |
+
+**Décisions de design clés :**
+- **Pourquoi un daemon ?** N bots = N processus. Un cache in-process donne à chaque bot sa propre vue. Un daemon donne une source de vérité unique avec une seule connexion rate-limitée.
+- **Pourquoi un socket Unix ?** Latence sub-ms (vs 10ms+ TCP), pas de conflit de ports, permissions filesystem, nettoyage automatique.
+- **Pourquoi ne PAS fallback en cas de rate-limit ?** Quand le daemon renvoie `CacheRateLimited`, retomber sur ccxt direct contourne le rate-limiter centralisé et double la pression. Le bot saute le cycle et retente au suivant.
+- **File de priorité :** CRITICAL (positions ouvertes) > HIGH (ordres live) > NORMAL (warmup) > LOW (dry_run). À niveau égal, les bots avec plus de capital passent en premier.
 
 #### Filtres de pairlist
 
@@ -360,6 +490,52 @@ Dans la section `pairlists` de ta config :
 ```
 
 Les paires dont la régression linéaire sur 30 jours a un R² au-dessus de `0.85` et une pente positive sont filtrées — hygiène utile pour les stratégies short only.
+
+#### Utiliser `ftcache` (daemon OHLCV partagé)
+
+Si tu fais tourner plusieurs bots sur le même wallet, `ftcache` élimine les cascades de rate-limit en routant tout le trafic API via un seul daemon.
+
+**1. Active-le dans la config de chaque bot :**
+
+```json
+{
+  "shared_ohlcv_cache": {
+    "enabled": true,
+    "socket_path": "/tmp/ftcache.sock",
+    "bot_id": "mon_bot_short",
+    "capital": 1000
+  }
+}
+```
+
+**2. Lance le daemon avant tes bots :**
+
+```bash
+python -m freqtrade.ohlcv_cache.daemon --config live_configs/mon_bot.json
+```
+
+**3. Lance tes bots normalement** — le `CachedExchangeMixin` intercepte automatiquement les appels exchange et les route via le daemon.
+
+**4. Monitoring via API ou CLI :**
+
+```bash
+# Healthcheck CLI
+python -m freqtrade.ohlcv_cache.healthcheck
+
+# Endpoint API (depuis n'importe quel bot en marche)
+curl http://localhost:8080/api/v1/cache_status
+```
+
+#### Utiliser `ftpairlists` (daemon pairlist partagé)
+
+Déduplique les calculs de filtres pairlist entre bots qui partagent des configs similaires. Particulièrement utile quand plusieurs bots utilisent des filtres lourds comme `TrendRegularityFilter` ou `VolatilityFilter`.
+
+```bash
+# Lance le daemon pairlist cache
+python -m freqtrade.pairlist_cache.daemon
+```
+
+L'intégration est automatique — quand le daemon tourne, les bots ayant des paramètres de filtres identiques partagent les résultats en cache au lieu de les calculer chacun de leur côté.
 
 ### Autres repos associés
 

--- a/freqtrade/commands/__init__.py
+++ b/freqtrade/commands/__init__.py
@@ -45,4 +45,5 @@ from freqtrade.commands.pairlist_commands import start_test_pairlist
 from freqtrade.commands.plot_commands import start_plot_dataframe, start_plot_profit
 from freqtrade.commands.strategy_utils_commands import start_strategy_update
 from freqtrade.commands.trade_commands import start_trading
+from freqtrade.commands.walk_forward_commands import start_walk_forward
 from freqtrade.commands.webserver_commands import start_webserver

--- a/freqtrade/commands/arguments.py
+++ b/freqtrade/commands/arguments.py
@@ -278,6 +278,29 @@ ARGS_LOOKAHEAD_ANALYSIS = [
 
 ARGS_RECURSIVE_ANALYSIS = ["timeframe", "timerange", "dataformat_ohlcv", "pairs", "startup_candle"]
 
+ARGS_WALK_FORWARD = [
+    *ARGS_COMMON_OPTIMIZE,
+    "hyperopt_path",
+    "position_stacking",
+    "enable_protections",
+    "dry_run_wallet",
+    "timeframe_detail",
+    "epochs",
+    "spaces",
+    "hyperopt_jobs",
+    "hyperopt_random_state",
+    "hyperopt_min_trades",
+    "hyperopt_loss",
+    "hyperopt_sampler",
+    "early_stop",
+    # Walk-forward specific
+    "wf_windows",
+    "wf_train_ratio",
+    "wf_embargo_days",
+    "wf_holdout_months",
+    "wf_min_test_trades",
+]
+
 # Command level configs - keep at the bottom of the above definitions
 NO_CONF_REQURIED = [
     "backtest-filter",
@@ -415,6 +438,7 @@ class Arguments:
             start_strategy_update,
             start_test_pairlist,
             start_trading,
+            start_walk_forward,
             start_webserver,
         )
 
@@ -717,3 +741,12 @@ class Arguments:
         recursive_analayis_cmd.set_defaults(func=start_recursive_analysis)
 
         self._build_args(optionlist=ARGS_RECURSIVE_ANALYSIS, parser=recursive_analayis_cmd)
+
+        # Add walk-forward subcommand
+        walk_forward_cmd = subparsers.add_parser(
+            "walk-forward",
+            help="Walk-forward analysis module.",
+            parents=[_common_parser, _strategy_parser],
+        )
+        walk_forward_cmd.set_defaults(func=start_walk_forward)
+        self._build_args(optionlist=ARGS_WALK_FORWARD, parser=walk_forward_cmd)

--- a/freqtrade/commands/arguments.py
+++ b/freqtrade/commands/arguments.py
@@ -299,6 +299,7 @@ ARGS_WALK_FORWARD = [
     "wf_embargo_days",
     "wf_holdout_months",
     "wf_min_test_trades",
+    "wf_mode",
 ]
 
 # Command level configs - keep at the bottom of the above definitions

--- a/freqtrade/commands/cli_options.py
+++ b/freqtrade/commands/cli_options.py
@@ -909,4 +909,12 @@ AVAILABLE_CLI_OPTIONS = {
         metavar="INT",
         default=30,
     ),
+    "wf_mode": Arg(
+        "--wf-mode",
+        help="Window mode: rolling (fixed-size sliding) or "
+        "anchored (train grows from start). Default: %(default)s.",
+        type=str,
+        choices=["rolling", "anchored"],
+        default="rolling",
+    ),
 }

--- a/freqtrade/commands/cli_options.py
+++ b/freqtrade/commands/cli_options.py
@@ -869,4 +869,44 @@ AVAILABLE_CLI_OPTIONS = {
         action="store_true",
         default=False,
     ),
+    # Walk-forward analysis
+    "wf_windows": Arg(
+        "--wf-windows",
+        help="Number of walk-forward windows (default: %(default)d).",
+        type=check_int_positive,
+        metavar="INT",
+        default=5,
+    ),
+    "wf_train_ratio": Arg(
+        "--wf-train-ratio",
+        help="Ratio of training data per window, range 0.5-0.9 "
+        "(default: %(default)s).",
+        type=float,
+        metavar="FLOAT",
+        default=0.75,
+    ),
+    "wf_embargo_days": Arg(
+        "--wf-embargo-days",
+        help="Embargo days between train and test windows for purging "
+        "(default: %(default)d).",
+        type=int,
+        metavar="INT",
+        default=7,
+    ),
+    "wf_holdout_months": Arg(
+        "--wf-holdout-months",
+        help="Reserve N months at end as final holdout. "
+        "0 = no holdout (default: %(default)d).",
+        type=int,
+        metavar="INT",
+        default=0,
+    ),
+    "wf_min_test_trades": Arg(
+        "--wf-min-test-trades",
+        help="Minimum trades per test window for significance "
+        "(default: %(default)d).",
+        type=check_int_positive,
+        metavar="INT",
+        default=30,
+    ),
 }

--- a/freqtrade/commands/optimize_commands.py
+++ b/freqtrade/commands/optimize_commands.py
@@ -24,6 +24,7 @@ def setup_optimize_configuration(args: dict[str, Any], method: RunMode) -> dict[
     no_unlimited_runmodes = {
         RunMode.BACKTEST: "backtesting",
         RunMode.HYPEROPT: "hyperoptimization",
+        RunMode.WALKFORWARD: "walk-forward analysis",
     }
     if method in no_unlimited_runmodes.keys():
         wallet_size = get_dry_run_wallet(config) * config["tradable_balance_ratio"]

--- a/freqtrade/commands/walk_forward_commands.py
+++ b/freqtrade/commands/walk_forward_commands.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from freqtrade.enums import RunMode
+from freqtrade.exceptions import OperationalException
+
+
+logger = logging.getLogger(__name__)
+
+
+def start_walk_forward(args: dict[str, Any]) -> None:
+    """Start Walk-forward analysis."""
+    try:
+        from filelock import FileLock, Timeout
+
+        from freqtrade.optimize.walk_forward import WalkForward
+    except ImportError as e:
+        raise OperationalException(
+            f"{e}. Please ensure that the hyperopt dependencies are installed."
+        ) from e
+
+    from freqtrade.commands.optimize_commands import setup_optimize_configuration
+
+    config = setup_optimize_configuration(args, RunMode.WALKFORWARD)
+
+    logger.info("Starting freqtrade in Walk-Forward Analysis mode")
+
+    lock = FileLock(WalkForward.get_lock_filename(config))
+
+    try:
+        with lock.acquire(timeout=1):
+            logging.getLogger("hyperopt.tpe").setLevel(logging.WARNING)
+            logging.getLogger("filelock").setLevel(logging.WARNING)
+
+            wfa = WalkForward(config)
+            wfa.start()
+
+    except Timeout:
+        logger.info(
+            "Another running instance of freqtrade Walk-Forward detected."
+        )
+        logger.info(
+            "Simultaneous execution is not supported. "
+            "Please run Walk-Forward analysis sequentially."
+        )

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -394,6 +394,16 @@ class Configuration:
 
         self._args_to_config_loop(config, configurations)
 
+        # Walk-forward section
+        configurations = [
+            ("wf_windows", "Parameter --wf-windows detected: {}"),
+            ("wf_train_ratio", "Parameter --wf-train-ratio detected: {}"),
+            ("wf_embargo_days", "Parameter --wf-embargo-days detected: {}"),
+            ("wf_holdout_months", "Parameter --wf-holdout-months detected: {}"),
+            ("wf_min_test_trades", "Parameter --wf-min-test-trades detected: {}"),
+        ]
+        self._args_to_config_loop(config, configurations)
+
     def _process_plot_options(self, config: Config) -> None:
         configurations = [
             ("pairs", "Using pairs {}"),

--- a/freqtrade/configuration/configuration.py
+++ b/freqtrade/configuration/configuration.py
@@ -401,6 +401,7 @@ class Configuration:
             ("wf_embargo_days", "Parameter --wf-embargo-days detected: {}"),
             ("wf_holdout_months", "Parameter --wf-holdout-months detected: {}"),
             ("wf_min_test_trades", "Parameter --wf-min-test-trades detected: {}"),
+            ("wf_mode", "Parameter --wf-mode detected: {}"),
         ]
         self._args_to_config_loop(config, configurations)
 

--- a/freqtrade/enums/runmode.py
+++ b/freqtrade/enums/runmode.py
@@ -11,6 +11,7 @@ class RunMode(StrEnum):
     DRY_RUN = "dry_run"
     BACKTEST = "backtest"
     HYPEROPT = "hyperopt"
+    WALKFORWARD = "walk_forward"
     UTIL_EXCHANGE = "util_exchange"
     UTIL_NO_EXCHANGE = "util_no_exchange"
     PLOT = "plot"
@@ -19,5 +20,5 @@ class RunMode(StrEnum):
 
 
 TRADE_MODES = [RunMode.LIVE, RunMode.DRY_RUN]
-OPTIMIZE_MODES = [RunMode.BACKTEST, RunMode.HYPEROPT]
+OPTIMIZE_MODES = [RunMode.BACKTEST, RunMode.HYPEROPT, RunMode.WALKFORWARD]
 NON_UTIL_MODES = TRADE_MODES + OPTIMIZE_MODES

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -1883,6 +1883,5 @@ class Backtesting:
                 )
             )
 
-        if len(self.strategylist) > 0:
-            # Show backtest results
+        if len(self.strategylist) > 0 and not self.config.get("wfa_silent"):
             show_backtest_results(self.config, self.results)

--- a/freqtrade/optimize/hyperopt/hyperopt.py
+++ b/freqtrade/optimize/hyperopt/hyperopt.py
@@ -43,6 +43,7 @@ class Hyperopt:
 
     def __init__(self, config: Config) -> None:
         self._hyper_out: HyperoptOutput = HyperoptOutput(streaming=True)
+        self._epoch_callback: Any | None = None
 
         self.config = config
 
@@ -216,6 +217,9 @@ class Hyperopt:
 
         self._save_result(val)
 
+        if self._epoch_callback:
+            self._epoch_callback(val)
+
     def start(self) -> None:
         self.random_state = self._set_random_state(self.config.get("hyperopt_random_state"))
         logger.info(f"Using optimizer random state: {self.random_state}")
@@ -234,7 +238,10 @@ class Hyperopt:
                 logger.info(f"Effective number of parallel workers used: {jobs}")
 
                 # Define progressbar
-                with get_progress_tracker(cust_callables=[self._hyper_out]) as pbar:
+                with get_progress_tracker(
+                    cust_callables=[self._hyper_out],
+                    disable=self.config.get("wfa_silent", False),
+                ) as pbar:
                     task = pbar.add_task("Epochs", total=self.total_epochs)
 
                     start = 0
@@ -308,9 +315,10 @@ class Hyperopt:
                 self.current_best_epoch,
             )
 
-            HyperoptTools.show_epoch_details(
-                self.current_best_epoch, self.total_epochs, self.print_json
-            )
+            if not self.config.get("wfa_silent"):
+                HyperoptTools.show_epoch_details(
+                    self.current_best_epoch, self.total_epochs, self.print_json
+                )
         elif self.num_epochs_saved > 0:
             print(
                 f"No good result found for given optimization function in {self.num_epochs_saved} "

--- a/freqtrade/optimize/walk_forward.py
+++ b/freqtrade/optimize/walk_forward.py
@@ -5,8 +5,9 @@ import logging
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
+from math import erf, log, sqrt
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import rapidjson
@@ -16,11 +17,16 @@ from freqtrade.exceptions import OperationalException
 from freqtrade.optimize.hyperopt_tools import HyperoptTools, hyperopt_serializer
 
 
+if TYPE_CHECKING:
+    from freqtrade.optimize.wfa_output import WFADashboard
+
+
 logger = logging.getLogger(__name__)
 
 HYPER_PARAMS_FILE_FORMAT = rapidjson.NM_NATIVE | rapidjson.NM_NAN
 PARAM_STABILITY_STABLE = 0.15
 PARAM_STABILITY_UNSTABLE = 0.30
+EULER_MASCHERONI = 0.5772156649
 
 
 @dataclass
@@ -62,6 +68,7 @@ class WalkForward:
         self.embargo_days: int = config.get("wf_embargo_days", 7)
         self.holdout_months: int = config.get("wf_holdout_months", 0)
         self.min_test_trades: int = config.get("wf_min_test_trades", 30)
+        self.wf_mode: str = config.get("wf_mode", "rolling")
         self.strategy_name: str = config["strategy"]
 
         self.results: list[WindowResult] = []
@@ -95,6 +102,11 @@ class WalkForward:
         return start, end
 
     def _compute_windows(self) -> list[WalkForwardWindow]:
+        if self.wf_mode == "anchored":
+            return self._compute_windows_anchored()
+        return self._compute_windows_rolling()
+
+    def _compute_windows_rolling(self) -> list[WalkForwardWindow]:
         full_start, full_end = self._parse_timerange()
         holdout_delta = timedelta(days=self.holdout_months * 30)
         usable_end = full_end - holdout_delta
@@ -128,10 +140,10 @@ class WalkForward:
                 f"Need at least 60 days. Reduce --wf-windows or "
                 f"expand --timerange."
             )
-        if test_days < 30:
+        if test_days < 20:
             raise OperationalException(
                 f"Test window too short ({test_days:.0f} days). "
-                f"Need at least 30 days. Reduce --wf-windows or "
+                f"Need at least 20 days. Reduce --wf-windows or "
                 f"expand --timerange."
             )
 
@@ -156,6 +168,63 @@ class WalkForward:
                     index=i,
                     train_start=t_start,
                     train_end=t_end,
+                    test_start=test_start,
+                    test_end=test_end,
+                )
+            )
+
+        return windows
+
+    def _compute_windows_anchored(self) -> list[WalkForwardWindow]:
+        """Anchored mode: train always starts at the beginning, growing
+        for each subsequent window. Test windows are sequential."""
+        full_start, full_end = self._parse_timerange()
+        holdout_delta = timedelta(days=self.holdout_months * 30)
+        usable_end = full_end - holdout_delta
+        total_days = (usable_end - full_start).days
+
+        if total_days <= 0:
+            raise OperationalException(
+                f"Not enough data after reserving {self.holdout_months} "
+                f"months holdout. Total range: "
+                f"{full_start:%Y-%m-%d} to {full_end:%Y-%m-%d}."
+            )
+
+        r = self.train_ratio
+        n = self.n_windows
+
+        step = total_days * (1 - r) / (r + n * (1 - r))
+        test_days = step - self.embargo_days
+        train_initial = total_days - n * step
+
+        if train_initial < 60:
+            raise OperationalException(
+                f"Initial train window too short ({train_initial:.0f} days). "
+                f"Need at least 60 days. Reduce --wf-windows or "
+                f"expand --timerange."
+            )
+        if test_days < 20:
+            raise OperationalException(
+                f"Test window too short ({test_days:.0f} days). "
+                f"Need at least 20 days. Reduce --wf-windows or "
+                f"expand --timerange."
+            )
+
+        embargo = timedelta(days=self.embargo_days)
+        windows = []
+        for i in range(n):
+            train_end = full_start + timedelta(days=train_initial + i * step)
+            test_start = train_end + embargo
+            test_end = test_start + timedelta(days=test_days)
+
+            if test_end > usable_end + timedelta(days=1):
+                test_end = usable_end
+
+            windows.append(
+                WalkForwardWindow(
+                    index=i,
+                    train_start=full_start,
+                    train_end=train_end,
                     test_start=test_start,
                     test_end=test_end,
                 )
@@ -222,7 +291,7 @@ class WalkForward:
         logger.info(f"Walk-Forward Analysis Plan — {self.strategy_name}")
         logger.info(
             f"Loss: {self.config.get('hyperopt_loss', 'default')} | "
-            f"{self.n_windows} windows | "
+            f"{self.n_windows} windows ({self.wf_mode}) | "
             f"{self.config.get('epochs', 150)} epochs/window"
         )
         logger.info("=" * 70)
@@ -304,18 +373,24 @@ class WalkForward:
     # ------------------------------------------------------------------
 
     def _run_hyperopt_window(
-        self, window: WalkForwardWindow, base_seed: int | None
+        self,
+        window: WalkForwardWindow,
+        base_seed: int | None,
+        dashboard: WFADashboard | None = None,
     ) -> dict[str, Any]:
         from freqtrade.optimize.hyperopt import Hyperopt
 
         cfg = deepcopy(self.config)
         cfg["timerange"] = window.train_timerange_str()
         cfg["runmode"] = "hyperopt"
+        cfg["wfa_silent"] = True
 
         if base_seed is not None:
             cfg["hyperopt_random_state"] = base_seed + window.index
 
         hyperopt = Hyperopt(cfg)
+        if dashboard:
+            hyperopt._epoch_callback = dashboard.on_epoch
         hyperopt.start()
 
         best = hyperopt.current_best_epoch
@@ -335,15 +410,21 @@ class WalkForward:
         cfg["timerange"] = timerange_str
         cfg["runmode"] = "backtest"
         cfg["export"] = "none"
+        cfg["wfa_silent"] = True
         cfg.pop("backtest_cache", None)
 
         bt = Backtesting(cfg)
         bt.start()
 
-        strat_results = {}
+        strat_results: dict[str, Any] = {}
         if bt.results and "strategy" in bt.results:
             strat_data = bt.results["strategy"].get(self.strategy_name, {})
             strat_results = self._extract_metrics(strat_data)
+
+            trades = strat_data.get("trades", [])
+            if trades:
+                profits = [t.get("profit_abs", 0) for t in trades]
+                strat_results.update(self._compute_concentration(profits))
 
         Backtesting.cleanup()
         return strat_results
@@ -360,6 +441,94 @@ class WalkForward:
             "profit_factor": strat_data.get("profit_factor", 0),
             "win_rate": strat_data.get("winrate", 0),
             "avg_duration": strat_data.get("holding_avg", ""),
+        }
+
+    # ------------------------------------------------------------------
+    # Market context (Improvement #2)
+    # ------------------------------------------------------------------
+
+    def _compute_market_context(
+        self, test_start: datetime, test_end: datetime
+    ) -> dict[str, float]:
+        """Load BTC data for the test period and compute context metrics."""
+        try:
+            from freqtrade.configuration.timerange import TimeRange
+            from freqtrade.data.history import load_pair_history
+            from freqtrade.enums import CandleType
+
+            tr_str = (
+                f"{test_start.strftime('%Y%m%d')}-"
+                f"{test_end.strftime('%Y%m%d')}"
+            )
+            tr = TimeRange.parse_timerange(tr_str)
+            trading_mode = self.config.get("trading_mode", "spot")
+            candle_type = (
+                CandleType.FUTURES if trading_mode == "futures"
+                else CandleType.SPOT
+            )
+            stake = self.config.get("stake_currency", "USDT")
+            if candle_type == CandleType.FUTURES:
+                btc_pair = f"BTC/{stake}:{stake}"
+            else:
+                btc_pair = f"BTC/{stake}"
+
+            df = load_pair_history(
+                pair=btc_pair,
+                timeframe="1d",
+                datadir=self.config["datadir"],
+                timerange=tr,
+                fill_up_missing=False,
+                candle_type=candle_type,
+            )
+            if df.empty or len(df) < 2:
+                return {}
+
+            btc_change = (df["close"].iloc[-1] / df["close"].iloc[0] - 1) * 100
+            atr = (df["high"] - df["low"]).mean() / df["close"].mean() * 100
+            daily_returns = df["close"].pct_change().dropna()
+            vol_ann = float(daily_returns.std() * np.sqrt(365) * 100)
+
+            cum_ret = (df["close"].iloc[-1] / df["close"].iloc[0]) - 1
+            if cum_ret > 0.10:
+                regime = "bull"
+            elif cum_ret < -0.10:
+                regime = "bear"
+            else:
+                regime = "range"
+
+            return {
+                "btc_change_pct": round(float(btc_change), 1),
+                "atr_pct": round(float(atr), 1),
+                "volatility_ann_pct": round(vol_ann, 1),
+                "regime": regime,
+            }
+        except Exception:
+            return {}
+
+    # ------------------------------------------------------------------
+    # Concentrated profit check (Improvement #3)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _compute_concentration(profits: list[float]) -> dict[str, float]:
+        """HHI and top-1 trade concentration from per-trade profits."""
+        if not profits:
+            return {"hhi": 0.0, "top1_pct": 0.0}
+
+        total_abs = sum(abs(p) for p in profits)
+        if total_abs < 1e-8:
+            return {"hhi": 0.0, "top1_pct": 0.0}
+
+        shares = [abs(p) / total_abs for p in profits]
+        hhi = sum(s**2 for s in shares)
+
+        pos_profits = [p for p in profits if p > 0]
+        total_pos = sum(pos_profits) if pos_profits else 0
+        top1 = max(pos_profits) / total_pos * 100 if total_pos > 0 else 0
+
+        return {
+            "hhi": round(hhi, 4),
+            "top1_pct": round(top1, 1),
         }
 
     # ------------------------------------------------------------------
@@ -431,10 +600,47 @@ class WalkForward:
         return stability
 
     @staticmethod
+    def _weighted_median(
+        values: list[float], weights: list[float]
+    ) -> float:
+        """Weighted median: value where cumulative weight reaches 50%."""
+        arr = np.array(values)
+        w = np.array(weights)
+        idx = np.argsort(arr)
+        sorted_vals = arr[idx]
+        cum_w = np.cumsum(w[idx])
+        cutoff = cum_w[-1] / 2.0
+        return float(sorted_vals[cum_w >= cutoff][0])
+
+    @staticmethod
+    def _resolve_consensus_value(
+        values: list[Any],
+        weights: list[float] | None,
+        w_list: list[float],
+    ) -> Any:
+        """Resolve a single parameter's consensus value."""
+        if all(isinstance(v, int | float) for v in values):
+            if weights is not None and len(w_list) == len(values):
+                med = WalkForward._weighted_median(
+                    [float(v) for v in values], w_list
+                )
+            else:
+                med = float(np.median(values))
+            if all(isinstance(v, int) for v in values):
+                return round(med)
+            return round(med, 6)
+
+        from collections import Counter
+
+        return Counter(values).most_common(1)[0][0]
+
+    @staticmethod
     def _compute_consensus_params(
         all_params: list[dict[str, Any]],
+        weights: list[float] | None = None,
     ) -> dict[str, Any]:
-        """Compute median per parameter across all windows."""
+        """Compute (weighted) median per parameter across all windows.
+        When weights are provided, uses weighted median (by test Calmar)."""
         consensus: dict[str, Any] = {}
 
         spaces: set[str] = set()
@@ -450,24 +656,58 @@ class WalkForward:
 
             for key in sorted(keys):
                 values = []
-                for p in all_params:
+                w_list: list[float] = []
+                for i, p in enumerate(all_params):
                     if space in p and isinstance(p[space], dict) and key in p[space]:
                         values.append(p[space][key])
+                        if weights is not None and i < len(weights):
+                            w_list.append(weights[i])
 
-                if not values:
-                    continue
-                if all(isinstance(v, int | float) for v in values):
-                    med = float(np.median(values))
-                    if all(isinstance(v, int) for v in values):
-                        consensus[space][key] = int(round(med))
-                    else:
-                        consensus[space][key] = round(med, 6)
-                else:
-                    from collections import Counter
-
-                    consensus[space][key] = Counter(values).most_common(1)[0][0]
+                if values:
+                    consensus[space][key] = WalkForward._resolve_consensus_value(
+                        values, weights, w_list
+                    )
 
         return consensus
+
+    # ------------------------------------------------------------------
+    # Deflated Sharpe Ratio (Improvement #5)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _norm_cdf(z: float) -> float:
+        return 0.5 * (1.0 + erf(z / sqrt(2.0)))
+
+    @staticmethod
+    def _deflated_sharpe_ratio(
+        sr_observed: float,
+        n_trials: int,
+        n_obs: int,
+        skewness: float = 0.0,
+        kurtosis: float = 3.0,
+    ) -> float:
+        """Bailey & Lopez de Prado (2014) Deflated Sharpe Ratio.
+        Returns probability that observed SR is statistically significant
+        given n_trials independent tests."""
+        if n_trials < 2 or n_obs < 2:
+            return 0.0
+
+        ln_n = log(max(n_trials, 2))
+        sr_benchmark = sqrt(2.0 * ln_n) * (
+            1.0 - EULER_MASCHERONI / (2.0 * ln_n)
+        )
+
+        se_sr = sqrt(
+            (1.0 - skewness * sr_observed
+             + ((kurtosis - 1.0) / 4.0) * sr_observed**2)
+            / max(n_obs - 1, 1)
+        )
+
+        if se_sr < 1e-10:
+            return 0.0
+
+        z = (sr_observed - sr_benchmark) / se_sr
+        return WalkForward._norm_cdf(z)
 
     @staticmethod
     def _compute_degradation(train: dict[str, Any], test: dict[str, Any]) -> dict[str, float]:
@@ -485,7 +725,7 @@ class WalkForward:
     # Export
     # ------------------------------------------------------------------
 
-    def _export_consensus_json(self, consensus: dict[str, Any], json_path: Path | None) -> Path:
+    def _export_consensus_json(self, consensus: dict[str, Any]) -> Path:
         ts = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
         filename = self._wfa_dir / (f"{self.strategy_name}_consensus_{ts}.json")
         export_data = {
@@ -503,20 +743,10 @@ class WalkForward:
                 number_mode=HYPER_PARAMS_FILE_FORMAT,
             )
         logger.info(f"Consensus params exported to {filename}")
-
-        if json_path:
-            with json_path.open("w") as f:
-                rapidjson.dump(
-                    export_data,
-                    f,
-                    indent=2,
-                    default=hyperopt_serializer,
-                    number_mode=HYPER_PARAMS_FILE_FORMAT,
-                )
-            logger.info(
-                f"Consensus params also written to {json_path} " f"(strategy co-located JSON)."
-            )
-
+        logger.info(
+            "To apply consensus params to the live strategy, copy this file to "
+            "the strategy's co-located JSON path."
+        )
         return filename
 
     def _export_results_json(
@@ -524,18 +754,21 @@ class WalkForward:
         all_results: list[WindowResult],
         stability: dict[str, dict[str, Any]],
         consensus: dict[str, Any],
+        dsr: float | None = None,
     ) -> Path:
         ts = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
         filename = self._wfa_dir / (f"{self.strategy_name}_wfa_results_{ts}.json")
 
-        data = {
+        data: dict[str, Any] = {
             "strategy": self.strategy_name,
             "hyperopt_loss": self.config.get("hyperopt_loss", ""),
             "epochs_per_window": self.config.get("epochs", 150),
             "n_windows": self.n_windows,
+            "wf_mode": self.wf_mode,
             "train_ratio": self.train_ratio,
             "embargo_days": self.embargo_days,
             "timestamp": datetime.now(UTC).isoformat(),
+            "deflated_sharpe_ratio": dsr,
             "windows": [],
             "holdout": None,
             "param_stability": stability,
@@ -633,6 +866,18 @@ class WalkForward:
                     f"({r.test_trade_count}) < minimum "
                     f"({self.min_test_trades})"
                 )
+            top1 = r.test_metrics.get("top1_pct", 0)
+            if top1 > 50:
+                warnings.append(
+                    f"Window {r.window.index + 1}: top-1 trade = "
+                    f"{top1:.0f}% of profit — concentrated"
+                )
+            hhi = r.test_metrics.get("hhi", 0)
+            if hhi > 0.15:
+                warnings.append(
+                    f"Window {r.window.index + 1}: HHI = "
+                    f"{hhi:.3f} — profit depends on few trades"
+                )
 
         unstable = [k for k, v in stability.items() if v.get("unstable", False)]
         if unstable:
@@ -660,13 +905,18 @@ class WalkForward:
 
     @staticmethod
     def _log_metrics_line(label: str, m: dict[str, Any]) -> None:
-        logger.info(
+        line = (
             f"  {label} | "
             f"Profit: {m.get('profit_pct', 0):+.1f}% | "
             f"Calmar: {m.get('calmar', 0):.2f} | "
             f"DD: {m.get('max_dd_pct', 0):.1f}% | "
             f"Trades: {m.get('trades', 0)}"
         )
+        if m.get("hhi"):
+            line += f" | HHI: {m['hhi']:.3f}"
+        if m.get("top1_pct"):
+            line += f" | Top1: {m['top1_pct']:.0f}%"
+        logger.info(line)
 
     def _log_window_result(self, r: WindowResult) -> None:
         w = r.window
@@ -681,9 +931,12 @@ class WalkForward:
 
         ctx = r.market_context
         if ctx:
+            regime = ctx.get("regime", "?")
             logger.info(
-                f"  Market: ATR {ctx.get('atr_pct', 0):.1f}% | "
-                f"BTC {ctx.get('btc_change_pct', 0):+.1f}%"
+                f"  Market: {regime} | "
+                f"BTC {ctx.get('btc_change_pct', 0):+.1f}% | "
+                f"ATR {ctx.get('atr_pct', 0):.1f}% | "
+                f"Vol {ctx.get('volatility_ann_pct', 0):.0f}%"
             )
 
         for label, m in [
@@ -746,15 +999,17 @@ class WalkForward:
         stability: dict[str, dict[str, Any]],
         consensus: dict[str, Any],
         warnings: list[str],
+        dsr: float | None = None,
     ) -> None:
         sep = "=" * 70
 
         logger.info("")
         logger.info(sep)
         logger.info(f"Walk-Forward Analysis Results - {self.strategy_name}")
+        mode = self.wf_mode
         logger.info(
             f"Loss: {self.config.get('hyperopt_loss', 'N/A')} | "
-            f"{len(all_results)} windows | "
+            f"{len(all_results)} windows ({mode}) | "
             f"{self.config.get('epochs', 150)} epochs/window"
         )
         logger.info(sep)
@@ -766,10 +1021,21 @@ class WalkForward:
 
         logger.info("")
         logger.info(f"{'=' * 25} CONSENSUS PARAMS " f"{'=' * 28}")
+        logger.info("  (weighted by test-period Calmar ratio)")
         for space, params in consensus.items():
             if isinstance(params, dict) and params:
                 parts = [f"{k}={v}" for k, v in params.items()]
                 logger.info(f"  {space}: {', '.join(parts)}")
+
+        if dsr is not None:
+            logger.info("")
+            logger.info(f"{'=' * 25} DEFLATED SHARPE " f"{'=' * 29}")
+            logger.info(
+                f"  DSR p-value: {dsr:.3f} "
+                f"({'significant' if dsr > 0.95 else 'weak' if dsr > 0.5 else 'not significant'})"
+            )
+            n_trials = self.config.get("epochs", 150) * len(all_results)
+            logger.info(f"  Corrected for {n_trials} total trials")
 
         self._log_holdout()
 
@@ -787,10 +1053,56 @@ class WalkForward:
         logger.info(sep)
 
     # ------------------------------------------------------------------
+    # Holdout
+    # ------------------------------------------------------------------
+
+    def _run_holdout(
+        self,
+        consensus: dict[str, Any],
+        default_params: dict[str, Any],
+        strategy_json: Path | None,
+        original_json_bytes: bytes | None,
+    ) -> None:
+        _, full_end = self._parse_timerange()
+        holdout_window = self._compute_holdout_window(full_end)
+        if not holdout_window or not consensus:
+            return
+
+        logger.info("")
+        logger.info("Running holdout backtest with consensus params...")
+        self._restore_params(consensus, strategy_json)
+        ho_test = self._run_backtest(holdout_window.test_timerange_str())
+
+        ho_baseline: dict[str, Any] = {}
+        if default_params:
+            self._restore_params(default_params, strategy_json)
+            ho_baseline = self._run_backtest(holdout_window.test_timerange_str())
+
+        self.holdout_result = WindowResult(
+            window=holdout_window,
+            test_metrics=ho_test,
+            baseline_metrics=ho_baseline,
+            test_trade_count=ho_test.get("trades", 0),
+        )
+
+        self._restore_original_json(strategy_json, original_json_bytes)
+
+    @staticmethod
+    def _restore_original_json(
+        strategy_json: Path | None, original_json_bytes: bytes | None
+    ) -> None:
+        if strategy_json and original_json_bytes is not None:
+            strategy_json.write_bytes(original_json_bytes)
+        elif strategy_json and strategy_json.exists():
+            strategy_json.unlink()
+
+    # ------------------------------------------------------------------
     # Main orchestration
     # ------------------------------------------------------------------
 
     def start(self) -> None:
+        from freqtrade.optimize.wfa_output import WFADashboard
+
         windows = self._compute_windows()
         self._validate(windows)
         self._print_plan(windows)
@@ -798,57 +1110,76 @@ class WalkForward:
         strategy_json = self._get_strategy_json_path()
         base_seed = self.config.get("hyperopt_random_state")
 
-        # Save default params for baseline backtests
-        default_params: dict[str, Any] = {}
+        original_json_bytes: bytes | None = None
         if strategy_json and strategy_json.exists():
-            with strategy_json.open("r") as f:
-                raw = rapidjson.load(f, number_mode=HYPER_PARAMS_FILE_FORMAT)
-                default_params = raw.get("params", {})
+            original_json_bytes = strategy_json.read_bytes()
+            backup_path = self._wfa_dir / f"{strategy_json.name}.backup"
+            backup_path.write_bytes(original_json_bytes)
+            logger.info(f"Backed up live strategy JSON to {backup_path}")
+
+        default_params: dict[str, Any] = {}
+        if original_json_bytes is not None:
+            raw = rapidjson.loads(
+                original_json_bytes.decode(), number_mode=HYPER_PARAMS_FILE_FORMAT
+            )
+            default_params = raw.get("params", {})
 
         all_params: list[dict[str, Any]] = []
+        dashboard = WFADashboard(
+            windows=windows,
+            strategy=self.strategy_name,
+            epochs_per_window=self.config.get("epochs", 150),
+            stake_currency=self.config.get("stake_currency", "USDT"),
+        )
 
         try:
-            for window in windows:
-                logger.info("")
-                logger.info(f"{'=' * 20} Window {window.index + 1}/" f"{len(windows)} {'=' * 20}")
+            with dashboard:
+                for window in windows:
+                    dashboard.set_window(window)
 
-                # 1. Delete co-located JSON (tip #21)
-                self._delete_strategy_json(strategy_json)
+                    self._delete_strategy_json(strategy_json)
 
-                # 2. Hyperopt on train
-                logger.info(f"Hyperopt: {window.train_timerange_str()}")
-                ho_result = self._run_hyperopt_window(window, base_seed)
-                train_metrics = ho_result.get("metrics", {})
+                    dashboard.set_phase("hyperopt")
+                    ho_result = self._run_hyperopt_window(window, base_seed, dashboard)
+                    train_metrics = ho_result.get("metrics", {})
 
-                # 3. Save params
-                params = self._save_window_params(window.index, strategy_json)
-                all_params.append(ho_result.get("params", {}))
+                    params = self._save_window_params(window.index, strategy_json)
+                    all_params.append(ho_result.get("params", {}))
 
-                # 4. Backtest on test with optimized params
-                logger.info(f"Backtest (optimized): " f"{window.test_timerange_str()}")
-                test_metrics = self._run_backtest(window.test_timerange_str())
+                    dashboard.set_phase("backtest_optimized")
+                    test_metrics = self._run_backtest(window.test_timerange_str())
 
-                # 5. Baseline backtest (default params)
-                baseline_metrics: dict[str, Any] = {}
-                if default_params:
-                    self._restore_params(default_params, strategy_json)
-                    logger.info(f"Backtest (baseline): " f"{window.test_timerange_str()}")
-                    baseline_metrics = self._run_backtest(window.test_timerange_str())
+                    baseline_metrics: dict[str, Any] = {}
+                    if default_params:
+                        self._restore_params(default_params, strategy_json)
+                        dashboard.set_phase("backtest_baseline")
+                        baseline_metrics = self._run_backtest(window.test_timerange_str())
 
-                result = WindowResult(
-                    window=window,
-                    train_metrics=train_metrics,
-                    test_metrics=test_metrics,
-                    baseline_metrics=baseline_metrics,
-                    params=params,
-                    test_trade_count=test_metrics.get("trades", 0),
-                )
-                self.results.append(result)
+                    market_ctx = self._compute_market_context(
+                        window.test_start, window.test_end
+                    )
 
-                gc.collect()
+                    result = WindowResult(
+                        window=window,
+                        train_metrics=train_metrics,
+                        test_metrics=test_metrics,
+                        baseline_metrics=baseline_metrics,
+                        market_context=market_ctx,
+                        params=params,
+                        test_trade_count=test_metrics.get("trades", 0),
+                    )
+                    self.results.append(result)
+                    dashboard.complete_window(result)
+
+                    gc.collect()
 
         except KeyboardInterrupt:
             logger.info(f"Interrupted. Partial results for " f"{len(self.results)} window(s).")
+
+        finally:
+            self._restore_original_json(strategy_json, original_json_bytes)
+            if strategy_json:
+                logger.info(f"Restored original strategy JSON: {strategy_json}")
 
         if not self.results:
             logger.warning("No windows completed. Nothing to report.")
@@ -858,35 +1189,33 @@ class WalkForward:
         search_ranges = self._get_search_ranges()
         stability = self._analyze_param_stability(all_params[: len(self.results)], search_ranges)
 
-        # Consensus params
-        consensus = self._compute_consensus_params(all_params[: len(self.results)])
+        # Weighted consensus: weight by test-period Calmar
+        calmar_weights = [
+            max(r.test_metrics.get("calmar", 0), 0.01)
+            for r in self.results
+        ]
+        consensus = self._compute_consensus_params(
+            all_params[: len(self.results)], weights=calmar_weights
+        )
 
-        # Holdout
-        _, full_end = self._parse_timerange()
-        holdout_window = self._compute_holdout_window(full_end)
-        if holdout_window and consensus:
-            logger.info("")
-            logger.info("Running holdout backtest with consensus params...")
-            self._restore_params(consensus, strategy_json)
-            ho_test = self._run_backtest(holdout_window.test_timerange_str())
+        # Deflated Sharpe Ratio
+        sharpes = [r.test_metrics.get("sharpe", 0) for r in self.results]
+        avg_sharpe = float(np.mean(sharpes)) if sharpes else 0.0
+        n_trials = self.config.get("epochs", 150) * len(self.results)
+        avg_trades = int(np.mean([
+            r.test_metrics.get("trades", 0) for r in self.results
+        ])) if self.results else 0
+        dsr = self._deflated_sharpe_ratio(
+            avg_sharpe, n_trials, max(avg_trades, 2)
+        )
 
-            ho_baseline: dict[str, Any] = {}
-            if default_params:
-                self._restore_params(default_params, strategy_json)
-                ho_baseline = self._run_backtest(holdout_window.test_timerange_str())
+        self._run_holdout(consensus, default_params, strategy_json, original_json_bytes)
 
-            self.holdout_result = WindowResult(
-                window=holdout_window,
-                test_metrics=ho_test,
-                baseline_metrics=ho_baseline,
-                test_trade_count=ho_test.get("trades", 0),
-            )
-
-        # Export consensus JSON
-        self._export_consensus_json(consensus, strategy_json)
+        # Export consensus JSON (to wfa_dir only, never overwrites live JSON)
+        self._export_consensus_json(consensus)
 
         # Export full results
-        self._export_results_json(self.results, stability, consensus)
+        self._export_results_json(self.results, stability, consensus, dsr=dsr)
 
         # Log and get run count
         run_count = self._log_wfa_run(self.results, stability)
@@ -895,4 +1224,4 @@ class WalkForward:
         warnings = self._generate_warning_flags(self.results, stability, run_count)
 
         # Report
-        self._format_report(self.results, stability, consensus, warnings)
+        self._format_report(self.results, stability, consensus, warnings, dsr=dsr)

--- a/freqtrade/optimize/walk_forward.py
+++ b/freqtrade/optimize/walk_forward.py
@@ -1,0 +1,898 @@
+from __future__ import annotations
+
+import gc
+import logging
+from copy import deepcopy
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import rapidjson
+
+from freqtrade.constants import Config
+from freqtrade.exceptions import OperationalException
+from freqtrade.optimize.hyperopt_tools import HyperoptTools, hyperopt_serializer
+
+
+logger = logging.getLogger(__name__)
+
+HYPER_PARAMS_FILE_FORMAT = rapidjson.NM_NATIVE | rapidjson.NM_NAN
+PARAM_STABILITY_STABLE = 0.15
+PARAM_STABILITY_UNSTABLE = 0.30
+
+
+@dataclass
+class WalkForwardWindow:
+    index: int
+    train_start: datetime
+    train_end: datetime
+    test_start: datetime
+    test_end: datetime
+
+    def train_timerange_str(self) -> str:
+        return f"{self.train_start.strftime('%Y%m%d')}-" f"{self.train_end.strftime('%Y%m%d')}"
+
+    def test_timerange_str(self) -> str:
+        return f"{self.test_start.strftime('%Y%m%d')}-" f"{self.test_end.strftime('%Y%m%d')}"
+
+
+@dataclass
+class WindowResult:
+    window: WalkForwardWindow
+    train_metrics: dict[str, Any] = field(default_factory=dict)
+    test_metrics: dict[str, Any] = field(default_factory=dict)
+    baseline_metrics: dict[str, Any] = field(default_factory=dict)
+    market_context: dict[str, float] = field(default_factory=dict)
+    params: dict[str, Any] = field(default_factory=dict)
+    test_trade_count: int = 0
+
+
+class WalkForward:
+    """
+    Walk-forward analysis: N sequential cycles of
+    hyperopt(train) -> backtest(test) with disjoint windows.
+    """
+
+    def __init__(self, config: Config) -> None:
+        self.config = config
+        self.n_windows: int = config.get("wf_windows", 5)
+        self.train_ratio: float = config.get("wf_train_ratio", 0.75)
+        self.embargo_days: int = config.get("wf_embargo_days", 7)
+        self.holdout_months: int = config.get("wf_holdout_months", 0)
+        self.min_test_trades: int = config.get("wf_min_test_trades", 30)
+        self.strategy_name: str = config["strategy"]
+
+        self.results: list[WindowResult] = []
+        self.holdout_result: WindowResult | None = None
+
+        self._wfa_dir = Path(config["user_data_dir"]) / "walk_forward"
+        self._wfa_dir.mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
+    def get_lock_filename(config: Config) -> str:
+        return str(Path(config["user_data_dir"]) / "walk_forward.lock")
+
+    # ------------------------------------------------------------------
+    # Window computation
+    # ------------------------------------------------------------------
+
+    def _parse_timerange(self) -> tuple[datetime, datetime]:
+        timerange_str = self.config.get("timerange", "")
+        if not timerange_str or "-" not in timerange_str:
+            raise OperationalException(
+                "Walk-forward analysis requires --timerange " "in format YYYYMMDD-YYYYMMDD."
+            )
+        parts = timerange_str.split("-")
+        if len(parts) != 2 or not parts[0] or not parts[1]:
+            raise OperationalException(
+                "Walk-forward analysis requires --timerange "
+                "in format YYYYMMDD-YYYYMMDD (both start and end)."
+            )
+        start = datetime.strptime(parts[0], "%Y%m%d").replace(tzinfo=UTC)
+        end = datetime.strptime(parts[1], "%Y%m%d").replace(tzinfo=UTC)
+        return start, end
+
+    def _compute_windows(self) -> list[WalkForwardWindow]:
+        full_start, full_end = self._parse_timerange()
+        holdout_delta = timedelta(days=self.holdout_months * 30)
+        usable_end = full_end - holdout_delta
+        total_days = (usable_end - full_start).days
+
+        if total_days <= 0:
+            raise OperationalException(
+                f"Not enough data after reserving {self.holdout_months} "
+                f"months holdout. Total range: "
+                f"{full_start:%Y-%m-%d} to {full_end:%Y-%m-%d}."
+            )
+
+        r = self.train_ratio
+        n = self.n_windows
+        embargo = timedelta(days=self.embargo_days)
+
+        total_embargo_days = self.embargo_days * n
+        effective_days = total_days - total_embargo_days
+        if effective_days <= 0:
+            raise OperationalException(
+                f"Not enough data after accounting for {n} embargo "
+                f"periods of {self.embargo_days} days each."
+            )
+
+        test_days = effective_days * (1 - r) / (r + n * (1 - r))
+        train_days = test_days * r / (1 - r)
+
+        if train_days < 60:
+            raise OperationalException(
+                f"Train window too short ({train_days:.0f} days). "
+                f"Need at least 60 days. Reduce --wf-windows or "
+                f"expand --timerange."
+            )
+        if test_days < 30:
+            raise OperationalException(
+                f"Test window too short ({test_days:.0f} days). "
+                f"Need at least 30 days. Reduce --wf-windows or "
+                f"expand --timerange."
+            )
+
+        step = test_days + self.embargo_days
+        windows = []
+        for i in range(n):
+            t_start = full_start + timedelta(days=i * step)
+            t_end = t_start + timedelta(days=train_days)
+            test_start = t_end + embargo
+            test_end = test_start + timedelta(days=test_days)
+
+            if test_end > usable_end + timedelta(days=1):
+                logger.warning(
+                    f"Window {i + 1} test end ({test_end:%Y-%m-%d}) "
+                    f"exceeds usable range ({usable_end:%Y-%m-%d}). "
+                    f"Clamping."
+                )
+                test_end = usable_end
+
+            windows.append(
+                WalkForwardWindow(
+                    index=i,
+                    train_start=t_start,
+                    train_end=t_end,
+                    test_start=test_start,
+                    test_end=test_end,
+                )
+            )
+
+        return windows
+
+    def _compute_holdout_window(self, full_end: datetime) -> WalkForwardWindow | None:
+        if self.holdout_months <= 0:
+            return None
+        holdout_start = full_end - timedelta(days=self.holdout_months * 30)
+        return WalkForwardWindow(
+            index=-1,
+            train_start=holdout_start,
+            train_end=holdout_start,
+            test_start=holdout_start,
+            test_end=full_end,
+        )
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    def _validate(self, windows: list[WalkForwardWindow]) -> None:
+        if not (0.5 <= self.train_ratio <= 0.9):
+            raise OperationalException(
+                f"--wf-train-ratio must be between 0.5 and 0.9, " f"got {self.train_ratio}."
+            )
+
+        for w in windows:
+            train_days = (w.train_end - w.train_start).days
+            if train_days > 18 * 30:
+                logger.warning(
+                    f"Window {w.index + 1}: train period is "
+                    f"{train_days} days (>{18 * 30}). "
+                    f"Risk of fitting to outdated regimes (tip #26)."
+                )
+
+        if not self.config.get("timeframe_detail"):
+            logger.warning(
+                "No --timeframe-detail specified. DCA/stoploss fills "
+                "will be simulated at candle open price, which "
+                "overestimates results (tip #20)."
+            )
+
+        epochs = self.config.get("epochs", 150)
+        if epochs > 300:
+            logger.warning(
+                f"Epochs per window ({epochs}) > 300. " f"Risk of per-window overfitting (tip #14)."
+            )
+
+        if 0 < self.holdout_months < 2:
+            logger.warning(
+                f"Holdout of {self.holdout_months} month(s) may be too "
+                f"short to catch regime shifts. Consider >= 2 months."
+            )
+
+    # ------------------------------------------------------------------
+    # Plan display
+    # ------------------------------------------------------------------
+
+    def _print_plan(self, windows: list[WalkForwardWindow]) -> None:
+        logger.info("=" * 70)
+        logger.info(f"Walk-Forward Analysis Plan — {self.strategy_name}")
+        logger.info(
+            f"Loss: {self.config.get('hyperopt_loss', 'default')} | "
+            f"{self.n_windows} windows | "
+            f"{self.config.get('epochs', 150)} epochs/window"
+        )
+        logger.info("=" * 70)
+
+        for w in windows:
+            embargo_str = f" [{self.embargo_days}d embargo]"
+            logger.info(
+                f"  Window {w.index + 1}: "
+                f"Train {w.train_start:%Y-%m-%d} -> "
+                f"{w.train_end:%Y-%m-%d} |"
+                f"{embargo_str} | "
+                f"Test {w.test_start:%Y-%m-%d} -> "
+                f"{w.test_end:%Y-%m-%d}"
+            )
+
+        if self.holdout_months > 0:
+            _, full_end = self._parse_timerange()
+            ho = self._compute_holdout_window(full_end)
+            if ho:
+                logger.info(
+                    f"  Holdout: {ho.test_start:%Y-%m-%d} -> " f"{ho.test_end:%Y-%m-%d} (untouched)"
+                )
+
+        logger.info("=" * 70)
+
+    # ------------------------------------------------------------------
+    # Strategy JSON helpers
+    # ------------------------------------------------------------------
+
+    def _get_strategy_json_path(self) -> Path | None:
+        fn = HyperoptTools.get_strategy_filename(self.config, self.strategy_name)
+        if fn:
+            return fn.with_suffix(".json")
+        return None
+
+    def _delete_strategy_json(self, json_path: Path | None) -> None:
+        if json_path and json_path.exists():
+            json_path.unlink()
+            logger.info(f"Deleted co-located JSON: {json_path}")
+
+    def _save_window_params(self, window_index: int, json_path: Path | None) -> dict[str, Any]:
+        if not json_path or not json_path.exists():
+            return {}
+        with json_path.open("r") as f:
+            params = rapidjson.load(f, number_mode=HYPER_PARAMS_FILE_FORMAT)
+
+        dest = self._wfa_dir / f"window_{window_index}_params.json"
+        with dest.open("w") as f:
+            rapidjson.dump(
+                params,
+                f,
+                indent=2,
+                default=hyperopt_serializer,
+                number_mode=HYPER_PARAMS_FILE_FORMAT,
+            )
+        return params.get("params", {})
+
+    def _restore_params(self, params_dict: dict[str, Any], json_path: Path | None) -> None:
+        """Write params to the co-located JSON so Backtesting loads them."""
+        if not json_path:
+            return
+        export_data = {
+            "strategy_name": self.strategy_name,
+            "params": params_dict,
+            "ft_stratparam_v": 1,
+            "export_time": datetime.now(UTC).isoformat(),
+        }
+        with json_path.open("w") as f:
+            rapidjson.dump(
+                export_data,
+                f,
+                indent=2,
+                default=hyperopt_serializer,
+                number_mode=HYPER_PARAMS_FILE_FORMAT,
+            )
+
+    # ------------------------------------------------------------------
+    # Hyperopt / Backtest runners
+    # ------------------------------------------------------------------
+
+    def _run_hyperopt_window(
+        self, window: WalkForwardWindow, base_seed: int | None
+    ) -> dict[str, Any]:
+        from freqtrade.optimize.hyperopt import Hyperopt
+
+        cfg = deepcopy(self.config)
+        cfg["timerange"] = window.train_timerange_str()
+        cfg["runmode"] = "hyperopt"
+
+        if base_seed is not None:
+            cfg["hyperopt_random_state"] = base_seed + window.index
+
+        hyperopt = Hyperopt(cfg)
+        hyperopt.start()
+
+        best = hyperopt.current_best_epoch
+        if best:
+            raw_metrics = best.get("results_metrics", {})
+            return {
+                "loss": best.get("loss", 0),
+                "params": best.get("params_details", {}),
+                "metrics": self._extract_metrics(raw_metrics),
+            }
+        return {"loss": 0, "params": {}, "metrics": {}}
+
+    def _run_backtest(self, timerange_str: str) -> dict[str, Any]:
+        from freqtrade.optimize.backtesting import Backtesting
+
+        cfg = deepcopy(self.config)
+        cfg["timerange"] = timerange_str
+        cfg["runmode"] = "backtest"
+        cfg["export"] = "none"
+        cfg.pop("backtest_cache", None)
+
+        bt = Backtesting(cfg)
+        bt.start()
+
+        strat_results = {}
+        if bt.results and "strategy" in bt.results:
+            strat_data = bt.results["strategy"].get(self.strategy_name, {})
+            strat_results = self._extract_metrics(strat_data)
+
+        Backtesting.cleanup()
+        return strat_results
+
+    def _extract_metrics(self, strat_data: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "profit_pct": strat_data.get("profit_total", 0) * 100,
+            "profit_abs": strat_data.get("profit_total_abs", 0),
+            "trades": strat_data.get("total_trades", 0),
+            "calmar": strat_data.get("calmar", 0),
+            "sharpe": strat_data.get("sharpe", 0),
+            "sortino": strat_data.get("sortino", 0),
+            "max_dd_pct": strat_data.get("max_drawdown_account", 0) * 100,
+            "profit_factor": strat_data.get("profit_factor", 0),
+            "win_rate": strat_data.get("winrate", 0),
+            "avg_duration": strat_data.get("holding_avg", ""),
+        }
+
+    # ------------------------------------------------------------------
+    # Param stability analysis
+    # ------------------------------------------------------------------
+
+    def _get_search_ranges(self) -> dict[str, tuple[float, float]]:
+        """Extract parameter search ranges from the strategy."""
+        from freqtrade.resolvers.strategy_resolver import StrategyResolver
+        from freqtrade.strategy.parameters import NumericParameter
+
+        strategy = StrategyResolver.load_strategy(self.config)
+        ranges: dict[str, tuple[float, float]] = {}
+
+        for attr_name in dir(strategy):
+            attr = getattr(strategy, attr_name, None)
+            if isinstance(attr, NumericParameter):
+                ranges[attr_name] = (float(attr.low), float(attr.high))
+
+        return ranges
+
+    @staticmethod
+    def _analyze_param_stability(
+        all_params: list[dict[str, Any]],
+        search_ranges: dict[str, tuple[float, float]],
+    ) -> dict[str, dict[str, Any]]:
+        stability: dict[str, dict[str, Any]] = {}
+
+        all_keys: set[str] = set()
+        for p in all_params:
+            for space_params in p.values():
+                if isinstance(space_params, dict):
+                    all_keys.update(space_params.keys())
+
+        for key in sorted(all_keys):
+            values = []
+            for p in all_params:
+                for space_params in p.values():
+                    if isinstance(space_params, dict) and key in space_params:
+                        val = space_params[key]
+                        if isinstance(val, int | float):
+                            values.append(float(val))
+
+            if len(values) < 2:
+                continue
+
+            arr = np.array(values)
+            mean = float(np.mean(arr))
+            std = float(np.std(arr))
+            median = float(np.median(arr))
+
+            if key in search_ranges:
+                lo, hi = search_ranges[key]
+                search_range = hi - lo
+                std_over_range = std / search_range if search_range > 0 else 0
+            else:
+                std_over_range = std / abs(mean) if abs(mean) > 1e-8 else 0
+
+            stability[key] = {
+                "values": [round(v, 4) for v in values],
+                "mean": round(mean, 4),
+                "std": round(std, 4),
+                "median": round(median, 4),
+                "std_over_range": round(std_over_range, 4),
+                "stable": std_over_range < PARAM_STABILITY_STABLE,
+                "unstable": std_over_range > PARAM_STABILITY_UNSTABLE,
+            }
+
+        return stability
+
+    @staticmethod
+    def _compute_consensus_params(
+        all_params: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Compute median per parameter across all windows."""
+        consensus: dict[str, Any] = {}
+
+        spaces: set[str] = set()
+        for p in all_params:
+            spaces.update(p.keys())
+
+        for space in sorted(spaces):
+            consensus[space] = {}
+            keys: set[str] = set()
+            for p in all_params:
+                if space in p and isinstance(p[space], dict):
+                    keys.update(p[space].keys())
+
+            for key in sorted(keys):
+                values = []
+                for p in all_params:
+                    if space in p and isinstance(p[space], dict) and key in p[space]:
+                        values.append(p[space][key])
+
+                if not values:
+                    continue
+                if all(isinstance(v, int | float) for v in values):
+                    med = float(np.median(values))
+                    if all(isinstance(v, int) for v in values):
+                        consensus[space][key] = int(round(med))
+                    else:
+                        consensus[space][key] = round(med, 6)
+                else:
+                    from collections import Counter
+
+                    consensus[space][key] = Counter(values).most_common(1)[0][0]
+
+        return consensus
+
+    @staticmethod
+    def _compute_degradation(train: dict[str, Any], test: dict[str, Any]) -> dict[str, float]:
+        deg: dict[str, float] = {}
+        for key in ("profit_pct", "calmar", "sharpe", "profit_factor"):
+            tv = train.get(key, 0)
+            testv = test.get(key, 0)
+            if abs(tv) > 1e-8:
+                deg[key] = round((testv - tv) / abs(tv), 4)
+            else:
+                deg[key] = 0.0
+        return deg
+
+    # ------------------------------------------------------------------
+    # Export
+    # ------------------------------------------------------------------
+
+    def _export_consensus_json(self, consensus: dict[str, Any], json_path: Path | None) -> Path:
+        ts = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        filename = self._wfa_dir / (f"{self.strategy_name}_consensus_{ts}.json")
+        export_data = {
+            "strategy_name": self.strategy_name,
+            "params": consensus,
+            "ft_stratparam_v": 1,
+            "export_time": datetime.now(UTC).isoformat(),
+        }
+        with filename.open("w") as f:
+            rapidjson.dump(
+                export_data,
+                f,
+                indent=2,
+                default=hyperopt_serializer,
+                number_mode=HYPER_PARAMS_FILE_FORMAT,
+            )
+        logger.info(f"Consensus params exported to {filename}")
+
+        if json_path:
+            with json_path.open("w") as f:
+                rapidjson.dump(
+                    export_data,
+                    f,
+                    indent=2,
+                    default=hyperopt_serializer,
+                    number_mode=HYPER_PARAMS_FILE_FORMAT,
+                )
+            logger.info(
+                f"Consensus params also written to {json_path} " f"(strategy co-located JSON)."
+            )
+
+        return filename
+
+    def _export_results_json(
+        self,
+        all_results: list[WindowResult],
+        stability: dict[str, dict[str, Any]],
+        consensus: dict[str, Any],
+    ) -> Path:
+        ts = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        filename = self._wfa_dir / (f"{self.strategy_name}_wfa_results_{ts}.json")
+
+        data = {
+            "strategy": self.strategy_name,
+            "hyperopt_loss": self.config.get("hyperopt_loss", ""),
+            "epochs_per_window": self.config.get("epochs", 150),
+            "n_windows": self.n_windows,
+            "train_ratio": self.train_ratio,
+            "embargo_days": self.embargo_days,
+            "timestamp": datetime.now(UTC).isoformat(),
+            "windows": [],
+            "holdout": None,
+            "param_stability": stability,
+            "consensus_params": consensus,
+        }
+
+        for r in all_results:
+            data["windows"].append(
+                {
+                    "index": r.window.index + 1,
+                    "train_range": r.window.train_timerange_str(),
+                    "test_range": r.window.test_timerange_str(),
+                    "train_metrics": r.train_metrics,
+                    "test_metrics": r.test_metrics,
+                    "baseline_metrics": r.baseline_metrics,
+                    "market_context": r.market_context,
+                    "params": r.params,
+                    "degradation": self._compute_degradation(r.train_metrics, r.test_metrics),
+                }
+            )
+
+        if self.holdout_result:
+            data["holdout"] = {
+                "test_range": (self.holdout_result.window.test_timerange_str()),
+                "test_metrics": self.holdout_result.test_metrics,
+                "baseline_metrics": self.holdout_result.baseline_metrics,
+            }
+
+        with filename.open("w") as f:
+            rapidjson.dump(
+                data,
+                f,
+                indent=2,
+                default=hyperopt_serializer,
+                number_mode=HYPER_PARAMS_FILE_FORMAT,
+            )
+        logger.info(f"Full WFA results exported to {filename}")
+        return filename
+
+    def _log_wfa_run(
+        self,
+        all_results: list[WindowResult],
+        stability: dict[str, dict[str, Any]],
+    ) -> int:
+        """Append to persistent WFA log and return run count."""
+        log_file = self._wfa_dir / "wfa_log.jsonl"
+        prior_count = 0
+        if log_file.exists():
+            prior_count = sum(1 for line in log_file.read_text().splitlines() if line.strip())
+
+        profitable_windows = sum(1 for r in all_results if r.test_metrics.get("profit_pct", 0) > 0)
+        stable_params = sum(1 for s in stability.values() if s.get("stable", False))
+        total_params = len(stability)
+
+        entry = {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "strategy": self.strategy_name,
+            "hyperopt_loss": self.config.get("hyperopt_loss", ""),
+            "windows": self.n_windows,
+            "windows_completed": len(all_results),
+            "profitable_windows": profitable_windows,
+            "stable_params": stable_params,
+            "total_params": total_params,
+            "timerange": self.config.get("timerange", ""),
+        }
+
+        with log_file.open("a") as f:
+            f.write(
+                rapidjson.dumps(
+                    entry,
+                    default=hyperopt_serializer,
+                    number_mode=HYPER_PARAMS_FILE_FORMAT,
+                )
+                + "\n"
+            )
+
+        return prior_count + 1
+
+    # ------------------------------------------------------------------
+    # Warning flags
+    # ------------------------------------------------------------------
+
+    def _generate_warning_flags(
+        self,
+        all_results: list[WindowResult],
+        stability: dict[str, dict[str, Any]],
+        run_count: int,
+    ) -> list[str]:
+        warnings: list[str] = []
+
+        for r in all_results:
+            if r.test_trade_count < self.min_test_trades:
+                warnings.append(
+                    f"Window {r.window.index + 1} test trades "
+                    f"({r.test_trade_count}) < minimum "
+                    f"({self.min_test_trades})"
+                )
+
+        unstable = [k for k, v in stability.items() if v.get("unstable", False)]
+        if unstable:
+            warnings.append(
+                f"Unstable parameters (std/range > "
+                f"{PARAM_STABILITY_UNSTABLE:.0%}): "
+                f"{', '.join(unstable)} -- consider freezing (tip #81)"
+            )
+
+        if not self.config.get("timeframe_detail"):
+            warnings.append("No --timeframe-detail: fills overestimated (tip #20)")
+
+        if run_count > 1:
+            warnings.append(
+                f"This is WFA run #{run_count} on {self.strategy_name}. "
+                f"More tests = higher chance of false positive by "
+                f"chance (tip #76, #180)"
+            )
+
+        return warnings
+
+    # ------------------------------------------------------------------
+    # Report
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _log_metrics_line(label: str, m: dict[str, Any]) -> None:
+        logger.info(
+            f"  {label} | "
+            f"Profit: {m.get('profit_pct', 0):+.1f}% | "
+            f"Calmar: {m.get('calmar', 0):.2f} | "
+            f"DD: {m.get('max_dd_pct', 0):.1f}% | "
+            f"Trades: {m.get('trades', 0)}"
+        )
+
+    def _log_window_result(self, r: WindowResult) -> None:
+        w = r.window
+        logger.info("")
+        logger.info(
+            f"--- Window {w.index + 1}: "
+            f"Train {w.train_start:%Y-%m-%d} -> "
+            f"{w.train_end:%Y-%m-%d} | "
+            f"Test {w.test_start:%Y-%m-%d} -> "
+            f"{w.test_end:%Y-%m-%d} ---"
+        )
+
+        ctx = r.market_context
+        if ctx:
+            logger.info(
+                f"  Market: ATR {ctx.get('atr_pct', 0):.1f}% | "
+                f"BTC {ctx.get('btc_change_pct', 0):+.1f}%"
+            )
+
+        for label, m in [
+            ("Train", r.train_metrics),
+            ("Test ", r.test_metrics),
+            ("Base ", r.baseline_metrics),
+        ]:
+            if m:
+                self._log_metrics_line(label, m)
+
+        deg = self._compute_degradation(r.train_metrics, r.test_metrics)
+        if deg:
+            parts = [f"{k}: {v:+.0%}" for k, v in deg.items() if abs(v) > 0.001]
+            if parts:
+                logger.info(f"  Degradation: {', '.join(parts)}")
+
+    @staticmethod
+    def _log_stability(
+        stability: dict[str, dict[str, Any]],
+    ) -> None:
+        if not stability:
+            return
+        logger.info("")
+        logger.info(f"{'=' * 25} PARAMETER STABILITY " f"{'=' * 25}")
+        for name, s in stability.items():
+            if s.get("unstable"):
+                flag = "UNSTABLE"
+            elif s.get("stable"):
+                flag = "stable"
+            else:
+                flag = "marginal"
+
+            logger.info(
+                f"  {name:30s} | "
+                f"median: {s['median']:8.4f} | "
+                f"std/range: {s['std_over_range']:.1%} | "
+                f"{flag:>10s} | "
+                f"{s['values']}"
+            )
+
+    def _log_holdout(self) -> None:
+        if not self.holdout_result:
+            return
+        logger.info("")
+        logger.info(f"{'=' * 25} HOLDOUT FINAL " f"{'=' * 31}")
+        ho = self.holdout_result
+        logger.info(
+            f"  Period: {ho.window.test_start:%Y-%m-%d} -> " f"{ho.window.test_end:%Y-%m-%d}"
+        )
+        for label, m in [
+            ("Consensus", ho.test_metrics),
+            ("Baseline ", ho.baseline_metrics),
+        ]:
+            if m:
+                self._log_metrics_line(label, m)
+
+    def _format_report(
+        self,
+        all_results: list[WindowResult],
+        stability: dict[str, dict[str, Any]],
+        consensus: dict[str, Any],
+        warnings: list[str],
+    ) -> None:
+        sep = "=" * 70
+
+        logger.info("")
+        logger.info(sep)
+        logger.info(f"Walk-Forward Analysis Results - {self.strategy_name}")
+        logger.info(
+            f"Loss: {self.config.get('hyperopt_loss', 'N/A')} | "
+            f"{len(all_results)} windows | "
+            f"{self.config.get('epochs', 150)} epochs/window"
+        )
+        logger.info(sep)
+
+        for r in all_results:
+            self._log_window_result(r)
+
+        self._log_stability(stability)
+
+        logger.info("")
+        logger.info(f"{'=' * 25} CONSENSUS PARAMS " f"{'=' * 28}")
+        for space, params in consensus.items():
+            if isinstance(params, dict) and params:
+                parts = [f"{k}={v}" for k, v in params.items()]
+                logger.info(f"  {space}: {', '.join(parts)}")
+
+        self._log_holdout()
+
+        if warnings:
+            logger.info("")
+            logger.info(f"{'=' * 25} WARNING FLAGS " f"{'=' * 31}")
+            for w in warnings:
+                logger.info(f"  * {w}")
+
+        logger.info("")
+        logger.info(
+            "Note: 5 windows = indication, not statistical proof. "
+            "Dry-run remains mandatory (tip #28)."
+        )
+        logger.info(sep)
+
+    # ------------------------------------------------------------------
+    # Main orchestration
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        windows = self._compute_windows()
+        self._validate(windows)
+        self._print_plan(windows)
+
+        strategy_json = self._get_strategy_json_path()
+        base_seed = self.config.get("hyperopt_random_state")
+
+        # Save default params for baseline backtests
+        default_params: dict[str, Any] = {}
+        if strategy_json and strategy_json.exists():
+            with strategy_json.open("r") as f:
+                raw = rapidjson.load(f, number_mode=HYPER_PARAMS_FILE_FORMAT)
+                default_params = raw.get("params", {})
+
+        all_params: list[dict[str, Any]] = []
+
+        try:
+            for window in windows:
+                logger.info("")
+                logger.info(f"{'=' * 20} Window {window.index + 1}/" f"{len(windows)} {'=' * 20}")
+
+                # 1. Delete co-located JSON (tip #21)
+                self._delete_strategy_json(strategy_json)
+
+                # 2. Hyperopt on train
+                logger.info(f"Hyperopt: {window.train_timerange_str()}")
+                ho_result = self._run_hyperopt_window(window, base_seed)
+                train_metrics = ho_result.get("metrics", {})
+
+                # 3. Save params
+                params = self._save_window_params(window.index, strategy_json)
+                all_params.append(ho_result.get("params", {}))
+
+                # 4. Backtest on test with optimized params
+                logger.info(f"Backtest (optimized): " f"{window.test_timerange_str()}")
+                test_metrics = self._run_backtest(window.test_timerange_str())
+
+                # 5. Baseline backtest (default params)
+                baseline_metrics: dict[str, Any] = {}
+                if default_params:
+                    self._restore_params(default_params, strategy_json)
+                    logger.info(f"Backtest (baseline): " f"{window.test_timerange_str()}")
+                    baseline_metrics = self._run_backtest(window.test_timerange_str())
+
+                result = WindowResult(
+                    window=window,
+                    train_metrics=train_metrics,
+                    test_metrics=test_metrics,
+                    baseline_metrics=baseline_metrics,
+                    params=params,
+                    test_trade_count=test_metrics.get("trades", 0),
+                )
+                self.results.append(result)
+
+                gc.collect()
+
+        except KeyboardInterrupt:
+            logger.info(f"Interrupted. Partial results for " f"{len(self.results)} window(s).")
+
+        if not self.results:
+            logger.warning("No windows completed. Nothing to report.")
+            return
+
+        # Stability analysis
+        search_ranges = self._get_search_ranges()
+        stability = self._analyze_param_stability(all_params[: len(self.results)], search_ranges)
+
+        # Consensus params
+        consensus = self._compute_consensus_params(all_params[: len(self.results)])
+
+        # Holdout
+        _, full_end = self._parse_timerange()
+        holdout_window = self._compute_holdout_window(full_end)
+        if holdout_window and consensus:
+            logger.info("")
+            logger.info("Running holdout backtest with consensus params...")
+            self._restore_params(consensus, strategy_json)
+            ho_test = self._run_backtest(holdout_window.test_timerange_str())
+
+            ho_baseline: dict[str, Any] = {}
+            if default_params:
+                self._restore_params(default_params, strategy_json)
+                ho_baseline = self._run_backtest(holdout_window.test_timerange_str())
+
+            self.holdout_result = WindowResult(
+                window=holdout_window,
+                test_metrics=ho_test,
+                baseline_metrics=ho_baseline,
+                test_trade_count=ho_test.get("trades", 0),
+            )
+
+        # Export consensus JSON
+        self._export_consensus_json(consensus, strategy_json)
+
+        # Export full results
+        self._export_results_json(self.results, stability, consensus)
+
+        # Log and get run count
+        run_count = self._log_wfa_run(self.results, stability)
+
+        # Warnings
+        warnings = self._generate_warning_flags(self.results, stability, run_count)
+
+        # Report
+        self._format_report(self.results, stability, consensus, warnings)

--- a/freqtrade/optimize/wfa_output.py
+++ b/freqtrade/optimize/wfa_output.py
@@ -1,0 +1,414 @@
+from __future__ import annotations
+
+import os
+import sys
+import time
+from typing import Any
+
+import numpy as np
+from rich.console import Console, Group
+from rich.live import Live
+from rich.panel import Panel
+from rich.progress import BarColumn, MofNCompleteColumn, Progress, TaskProgressColumn
+from rich.table import Table
+from rich.text import Text
+
+from freqtrade.optimize.walk_forward import WalkForwardWindow, WindowResult
+
+
+PHASE_LABELS = {
+    "hyperopt": "Hyperopt (train)",
+    "backtest_optimized": "Backtest (optimized params)",
+    "backtest_baseline": "Backtest (baseline params)",
+    "holdout_consensus": "Holdout (consensus params)",
+    "holdout_baseline": "Holdout (baseline params)",
+    "done": "Done",
+}
+
+
+class WFADashboard:
+    def __init__(
+        self,
+        windows: list[WalkForwardWindow],
+        strategy: str,
+        epochs_per_window: int,
+        stake_currency: str,
+    ) -> None:
+        self._windows = windows
+        self._n_windows = len(windows)
+        self._strategy = strategy
+        self._epochs = epochs_per_window
+        self._stake = stake_currency
+
+        self._current_idx = 0
+        self._current_window: WalkForwardWindow | None = None
+        self._phase = "hyperopt"
+
+        self._ho_epoch = 0
+        self._ho_total = epochs_per_window
+        self._ho_best: dict[str, Any] | None = None
+
+        self._completed: list[WindowResult] = []
+        self._phase_log: dict[int, dict[str, str]] = {}
+        for i in range(self._n_windows):
+            self._phase_log[i] = {
+                "hyperopt": "pending",
+                "backtest_optimized": "pending",
+                "backtest_baseline": "pending",
+            }
+
+        self._start_time = time.monotonic()
+        self._live: Live | None = None
+        self._saved_fds: dict[int, int] = {}
+        self._devnull_fd: int = -1
+
+    def __enter__(self) -> WFADashboard:
+        # Redirect stdout/stderr to /dev/null at the OS fd level.
+        # Only the Live display keeps a handle to the real terminal.
+        # This catches ALL output: loggers, print(), C extensions,
+        # libraries creating handlers after this point (tvDatafeed, etc.)
+        try:
+            stderr_fd = sys.stderr.fileno()
+            stdout_fd = sys.stdout.fileno()
+        except (AttributeError, OSError):
+            self._live = Live(
+                console=Console(stderr=True),
+                screen=True,
+                refresh_per_second=1,
+                get_renderable=self._build,
+            )
+            self._live.__enter__()
+            return self
+
+        # Redirect stdout/stderr to /dev/null at the OS fd level.
+        # Only Live keeps a handle to the real terminal via os.dup().
+        real_stderr_dup = os.dup(stderr_fd)
+        self._saved_fds[stderr_fd] = real_stderr_dup
+
+        real_stdout_dup = os.dup(stdout_fd)
+        self._saved_fds[stdout_fd] = real_stdout_dup
+
+        self._devnull_fd = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(self._devnull_fd, stderr_fd)
+        os.dup2(self._devnull_fd, stdout_fd)
+
+        real_stderr_file = os.fdopen(real_stderr_dup, "w", closefd=False)
+        # screen=True: uses alternate terminal buffer (like htop/vim).
+        # Each refresh redraws the ENTIRE screen — no cursor
+        # repositioning, so stray output can never cause duplication.
+        self._live = Live(
+            console=Console(file=real_stderr_file),
+            screen=True,
+            refresh_per_second=1,
+            get_renderable=self._build,
+        )
+        self._live.__enter__()
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        if self._live:
+            self._live.__exit__(*args)
+            self._live = None
+
+        for original_fd, dup_fd in self._saved_fds.items():
+            os.dup2(dup_fd, original_fd)
+            os.close(dup_fd)
+        self._saved_fds.clear()
+
+        if self._devnull_fd >= 0:
+            os.close(self._devnull_fd)
+            self._devnull_fd = -1
+
+    def set_window(self, window: WalkForwardWindow) -> None:
+        self._current_idx = window.index
+        self._current_window = window
+        self._phase = "hyperopt"
+        self._ho_epoch = 0
+        self._ho_best = None
+        for key in self._phase_log[window.index]:
+            self._phase_log[window.index][key] = "pending"
+        self._phase_log[window.index]["hyperopt"] = "active"
+        self._refresh()
+
+    def set_phase(self, phase: str) -> None:
+        if self._current_idx in self._phase_log:
+            old = self._phase
+            if old in self._phase_log[self._current_idx]:
+                self._phase_log[self._current_idx][old] = "done"
+            if phase in self._phase_log[self._current_idx]:
+                self._phase_log[self._current_idx][phase] = "active"
+        self._phase = phase
+        self._refresh()
+
+    def on_epoch(self, val: dict[str, Any]) -> None:
+        self._ho_epoch = val.get("current_epoch", 0)
+        self._ho_total = max(self._ho_total, self._ho_epoch)
+        if val.get("is_best"):
+            self._ho_best = val
+        self._refresh()
+
+    def complete_window(self, result: WindowResult) -> None:
+        self._completed.append(result)
+        for key in self._phase_log[self._current_idx]:
+            self._phase_log[self._current_idx][key] = "done"
+        self._refresh()
+
+    def _refresh(self) -> None:
+        if self._live:
+            self._live.update(self._build())
+
+    def _build(self) -> Panel:
+        parts: list[Any] = []
+
+        parts.append(self._build_header())
+        parts.append(Text(""))
+        parts.append(self._build_hyperopt_progress())
+        parts.append(Text(""))
+        parts.append(self._build_pipeline())
+
+        if self._completed:
+            parts.append(Text(""))
+            parts.append(self._build_completed_table())
+            parts.append(Text(""))
+            parts.append(self._build_insights())
+
+        return Panel(
+            Group(*parts),
+            title=f"[bold]Walk-Forward Analysis[/] — {self._strategy}",
+            border_style="cyan",
+        )
+
+    def _build_header(self) -> Text:
+        elapsed = time.monotonic() - self._start_time
+        m, s = divmod(int(elapsed), 60)
+        h, m = divmod(m, 60)
+        time_str = f"{h}:{m:02d}:{s:02d}" if h else f"{m}:{s:02d}"
+
+        phase_label = PHASE_LABELS.get(self._phase, self._phase)
+        line = (
+            f"Window {self._current_idx + 1}/{self._n_windows}"
+            f"  |  Phase: {phase_label}"
+            f"  |  Elapsed: {time_str}"
+        )
+
+        if self._current_window:
+            w = self._current_window
+            line += (
+                f"\nTrain: {w.train_start:%Y-%m-%d} -> "
+                f"{w.train_end:%Y-%m-%d}"
+                f"  |  Test: {w.test_start:%Y-%m-%d} -> "
+                f"{w.test_end:%Y-%m-%d}"
+            )
+        return Text(line)
+
+    def _build_hyperopt_progress(self) -> Group:
+        if self._phase != "hyperopt":
+            label = PHASE_LABELS.get(self._phase, self._phase)
+            return Group(Text(f"  {label}..."))
+
+        best_str = "—"
+        if self._ho_best:
+            rm = self._ho_best.get("results_metrics", {})
+            profit = rm.get("profit_total", 0) * 100
+            trades = rm.get("total_trades", 0)
+            dd = rm.get("max_drawdown_account", 0) * 100
+            loss = self._ho_best.get("loss", 0)
+            best_str = f"+{profit:.1f}%  {trades} trades" f"  DD {dd:.1f}%  loss {loss:.5f}"
+
+        info = Text(f"  Hyperopt: {self._ho_epoch}/{self._ho_total}" f"  |  Best: {best_str}")
+
+        pbar = Progress(
+            BarColumn(bar_width=None),
+            MofNCompleteColumn(),
+            TaskProgressColumn(),
+            expand=True,
+        )
+        task = pbar.add_task("", total=self._ho_total, completed=self._ho_epoch)
+        # Force render the progress bar without starting Live
+        pbar._tasks[task].completed = self._ho_epoch
+
+        return Group(info, pbar.get_renderable())
+
+    def _build_pipeline(self) -> Table:
+        table = Table(
+            show_header=False,
+            box=None,
+            padding=(0, 1),
+            expand=True,
+        )
+        table.add_column("Pipeline", ratio=1)
+
+        for i in range(self._n_windows):
+            phases = self._phase_log.get(i, {})
+            parts = []
+            for phase_key, label in [
+                ("hyperopt", "Hyperopt"),
+                ("backtest_optimized", "BT optim"),
+                ("backtest_baseline", "BT base"),
+            ]:
+                status = phases.get(phase_key, "pending")
+                if status == "done":
+                    parts.append(f"[green]v[/] {label}")
+                elif status == "active":
+                    parts.append(f"[yellow]>[/] [bold]{label}[/]")
+                else:
+                    parts.append(f"[dim]o {label}[/]")
+
+            line = f"  Window {i + 1}:  {'   '.join(parts)}"
+            table.add_row(line)
+
+        return table
+
+    def _build_completed_table(self) -> Table:
+        table = Table(title="Completed Windows", expand=True)
+        table.add_column("#", justify="right", width=3)
+        table.add_column("Test Period", justify="center")
+        table.add_column("Profit", justify="right")
+        table.add_column("Trades", justify="right")
+        table.add_column("Calmar", justify="right")
+        table.add_column("Max DD", justify="right")
+        table.add_column("HHI", justify="right")
+        table.add_column("Mkt", justify="center")
+        table.add_column("Baseline", justify="right")
+
+        for r in self._completed:
+            w = r.window
+            test_p = r.test_metrics.get("profit_pct", 0)
+            trades = r.test_metrics.get("trades", 0)
+            calmar = r.test_metrics.get("calmar", 0)
+            dd = r.test_metrics.get("max_dd_pct", 0)
+            hhi = r.test_metrics.get("hhi", 0)
+            base_p = r.baseline_metrics.get("profit_pct", 0)
+            regime = r.market_context.get("regime", "")
+
+            profit_style = "green" if test_p > 0 else "red"
+            base_style = "green" if base_p > 0 else "red"
+            hhi_style = "red" if hhi > 0.15 else "yellow" if hhi > 0.05 else ""
+
+            table.add_row(
+                str(w.index + 1),
+                f"{w.test_start:%m-%d} -> {w.test_end:%m-%d}",
+                Text(f"{test_p:+.1f}%", style=profit_style),
+                str(trades),
+                f"{calmar:.2f}",
+                f"{dd:.1f}%",
+                Text(f"{hhi:.3f}", style=hhi_style),
+                regime,
+                Text(f"{base_p:+.1f}%", style=base_style),
+            )
+
+        return table
+
+    def _build_insights(self) -> Panel:
+        lines: list[Text] = []
+        n = len(self._completed)
+
+        # --- Running verdicts ---
+        profits = [r.test_metrics.get("profit_pct", 0) for r in self._completed]
+        calmars = [r.test_metrics.get("calmar", 0) for r in self._completed]
+        win_count = sum(1 for p in profits if p > 0)
+        avg_profit = float(np.mean(profits))
+        avg_calmar = float(np.mean(calmars))
+
+        beats_baseline = sum(
+            1 for r in self._completed
+            if r.test_metrics.get("profit_pct", 0)
+            > r.baseline_metrics.get("profit_pct", float("-inf"))
+        )
+
+        # Verdict line
+        if win_count == n:
+            verdict = Text(f"  Verdict: {win_count}/{n} profitable", style="bold green")
+        elif win_count >= n / 2:
+            verdict = Text(f"  Verdict: {win_count}/{n} profitable", style="bold yellow")
+        else:
+            verdict = Text(f"  Verdict: {win_count}/{n} profitable", style="bold red")
+        lines.append(verdict)
+
+        # Average metrics
+        p_style = "green" if avg_profit > 0 else "red"
+        c_style = "green" if avg_calmar > 1 else "yellow" if avg_calmar > 0 else "red"
+        lines.append(Text(""))
+        lines.append(Text.assemble(
+            "  Avg profit: ",
+            (f"{avg_profit:+.1f}%", p_style),
+            "  |  Avg Calmar: ",
+            (f"{avg_calmar:.2f}", c_style),
+            f"  |  Beats baseline: {beats_baseline}/{n}",
+        ))
+
+        # Concentration alerts
+        high_hhi = [
+            r for r in self._completed
+            if r.test_metrics.get("hhi", 0) > 0.15
+        ]
+        if high_hhi:
+            lines.append(Text(
+                f"  [!] {len(high_hhi)} window(s) with concentrated"
+                f" profit (HHI > 0.15)",
+                style="yellow",
+            ))
+
+        # Emerging consensus params (top 5 most stable)
+        if n >= 2:
+            lines.append(Text(""))
+            lines.append(Text("  Emerging consensus params:", style="bold"))
+            params_table = self._build_param_preview()
+            if params_table:
+                lines.append(params_table)
+
+        return Panel(
+            Group(*lines),
+            title="[bold]Insights[/]",
+            border_style="blue",
+        )
+
+    def _build_param_preview(self) -> Table | None:
+        all_params: dict[str, list[float]] = {}
+        for r in self._completed:
+            for space_params in r.params.values():
+                if isinstance(space_params, dict):
+                    for k, v in space_params.items():
+                        if isinstance(v, int | float):
+                            all_params.setdefault(k, []).append(float(v))
+
+        if not all_params:
+            return None
+
+        table = Table(
+            show_header=True, box=None, padding=(0, 2), expand=True
+        )
+        table.add_column("Param", style="cyan")
+        table.add_column("Median", justify="right")
+        table.add_column("Spread", justify="right")
+        table.add_column("Stability", justify="center")
+        table.add_column("Values", style="dim")
+
+        items = sorted(
+            all_params.items(),
+            key=lambda kv: np.std(kv[1]) / max(abs(np.mean(kv[1])), 1e-8),
+        )
+
+        for name, vals in items[:8]:
+            med = float(np.median(vals))
+            std = float(np.std(vals))
+            mean = float(np.mean(vals))
+            cv = std / max(abs(mean), 1e-8)
+
+            if cv < 0.15:
+                stab = Text("stable", style="green")
+            elif cv < 0.30:
+                stab = Text("marginal", style="yellow")
+            else:
+                stab = Text("unstable", style="red")
+
+            vals_str = ", ".join(f"{v:.2f}" for v in vals)
+            table.add_row(
+                name,
+                f"{med:.4f}",
+                f"{std:.4f}",
+                stab,
+                vals_str,
+            )
+
+        return table

--- a/tests/optimize/test_walk_forward.py
+++ b/tests/optimize/test_walk_forward.py
@@ -1,0 +1,806 @@
+# pragma pylint: disable=missing-docstring,W0212,C0103
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import rapidjson
+from filelock import Timeout
+
+from freqtrade.commands.walk_forward_commands import start_walk_forward
+from freqtrade.enums import RunMode
+from freqtrade.exceptions import OperationalException
+from freqtrade.optimize.walk_forward import (
+    WalkForward,
+    WalkForwardWindow,
+    WindowResult,
+)
+from tests.conftest import (
+    get_args,
+    log_has,
+    log_has_re,
+    patch_exchange,
+    patched_configuration_load_config_file,
+)
+
+
+@pytest.fixture(scope="function")
+def walkforward_conf(default_conf, tmp_path):
+    wf_conf = deepcopy(default_conf)
+    wf_conf.update(
+        {
+            "runmode": RunMode.WALKFORWARD,
+            "strategy": "HyperoptableStrategy",
+            "hyperopt_loss": "ShortTradeDurHyperOptLoss",
+            "hyperopt_path": str(Path(__file__).parent / "hyperopts"),
+            "epochs": 1,
+            "timerange": "20180101-20200101",
+            "spaces": ["default"],
+            "hyperopt_jobs": 1,
+            "hyperopt_min_trades": 1,
+            "wf_windows": 3,
+            "wf_train_ratio": 0.75,
+            "wf_embargo_days": 7,
+            "wf_holdout_months": 0,
+            "wf_min_test_trades": 30,
+            "user_data_dir": tmp_path,
+        }
+    )
+    return wf_conf
+
+
+# ------------------------------------------------------------------
+# Window computation
+# ------------------------------------------------------------------
+
+
+class TestComputeWindows:
+    def test_basic_window_computation(self, walkforward_conf):
+        wf = WalkForward(walkforward_conf)
+        windows = wf._compute_windows()
+
+        assert len(windows) == 3
+        for i, w in enumerate(windows):
+            assert w.index == i
+            assert w.train_start < w.train_end
+            assert w.test_start < w.test_end
+            assert w.train_end <= w.test_start
+
+    def test_windows_disjoint_test_periods(self, walkforward_conf):
+        wf = WalkForward(walkforward_conf)
+        windows = wf._compute_windows()
+
+        for i in range(len(windows) - 1):
+            assert windows[i].test_end <= windows[i + 1].test_start
+
+    def test_embargo_gap(self, walkforward_conf):
+        wf = WalkForward(walkforward_conf)
+        windows = wf._compute_windows()
+
+        for w in windows:
+            gap = (w.test_start - w.train_end).days
+            assert gap == walkforward_conf["wf_embargo_days"]
+
+    def test_holdout_reserve(self, walkforward_conf):
+        walkforward_conf["wf_holdout_months"] = 3
+        wf = WalkForward(walkforward_conf)
+        windows = wf._compute_windows()
+        full_end = datetime.strptime("20200101", "%Y%m%d").replace(tzinfo=UTC)
+        holdout_start = full_end - timedelta(days=3 * 30)
+
+        for w in windows:
+            assert w.test_end <= holdout_start + timedelta(days=1)
+
+    def test_holdout_window(self, walkforward_conf):
+        walkforward_conf["wf_holdout_months"] = 2
+        wf = WalkForward(walkforward_conf)
+        full_end = datetime.strptime("20200101", "%Y%m%d").replace(tzinfo=UTC)
+        ho = wf._compute_holdout_window(full_end)
+
+        assert ho is not None
+        assert ho.test_end == full_end
+        assert ho.index == -1
+
+    def test_no_holdout_when_zero(self, walkforward_conf):
+        wf = WalkForward(walkforward_conf)
+        ho = wf._compute_holdout_window(datetime.strptime("20200101", "%Y%m%d").replace(tzinfo=UTC))
+        assert ho is None
+
+    def test_too_many_windows_raises(self, walkforward_conf):
+        walkforward_conf["wf_windows"] = 50
+        wf = WalkForward(walkforward_conf)
+        with pytest.raises(OperationalException, match=r"window too short"):
+            wf._compute_windows()
+
+    def test_short_timerange_raises(self, walkforward_conf):
+        walkforward_conf["timerange"] = "20180101-20180301"
+        walkforward_conf["wf_windows"] = 5
+        wf = WalkForward(walkforward_conf)
+        with pytest.raises(OperationalException, match=r"(Train|Test) window too short"):
+            wf._compute_windows()
+
+    def test_holdout_eats_all_data(self, walkforward_conf):
+        walkforward_conf["wf_holdout_months"] = 30
+        wf = WalkForward(walkforward_conf)
+        with pytest.raises(OperationalException, match=r"Not enough data"):
+            wf._compute_windows()
+
+    def test_large_embargo_raises(self, walkforward_conf):
+        walkforward_conf["wf_embargo_days"] = 300
+        wf = WalkForward(walkforward_conf)
+        with pytest.raises(OperationalException, match=r"Not enough data"):
+            wf._compute_windows()
+
+
+# ------------------------------------------------------------------
+# Timerange parsing
+# ------------------------------------------------------------------
+
+
+class TestParseTimerange:
+    def test_valid_timerange(self, walkforward_conf):
+        wf = WalkForward(walkforward_conf)
+        start, end = wf._parse_timerange()
+        assert start == datetime(2018, 1, 1, tzinfo=UTC)
+        assert end == datetime(2020, 1, 1, tzinfo=UTC)
+
+    def test_missing_timerange(self, walkforward_conf):
+        walkforward_conf["timerange"] = ""
+        wf = WalkForward(walkforward_conf)
+        with pytest.raises(OperationalException, match=r"requires --timerange"):
+            wf._parse_timerange()
+
+    def test_open_ended_timerange(self, walkforward_conf):
+        walkforward_conf["timerange"] = "20180101-"
+        wf = WalkForward(walkforward_conf)
+        with pytest.raises(OperationalException, match=r"both start and end"):
+            wf._parse_timerange()
+
+    def test_no_dash_timerange(self, walkforward_conf):
+        walkforward_conf["timerange"] = "20180101"
+        wf = WalkForward(walkforward_conf)
+        with pytest.raises(OperationalException, match=r"requires --timerange"):
+            wf._parse_timerange()
+
+
+# ------------------------------------------------------------------
+# Validation
+# ------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_invalid_train_ratio_low(self, walkforward_conf):
+        walkforward_conf["wf_train_ratio"] = 0.3
+        wf = WalkForward(walkforward_conf)
+        windows = wf._compute_windows()
+        with pytest.raises(OperationalException, match=r"must be between 0.5 and 0.9"):
+            wf._validate(windows)
+
+    def test_invalid_train_ratio_high(self, walkforward_conf):
+        walkforward_conf["wf_train_ratio"] = 0.95
+        wf = WalkForward(walkforward_conf)
+        windows = wf._compute_windows()
+        with pytest.raises(OperationalException, match=r"must be between 0.5 and 0.9"):
+            wf._validate(windows)
+
+    def test_long_train_period_warning(self, walkforward_conf, caplog):
+        walkforward_conf["wf_windows"] = 1
+        walkforward_conf["timerange"] = "20150101-20200101"
+        wf = WalkForward(walkforward_conf)
+        windows = wf._compute_windows()
+        wf._validate(windows)
+        assert log_has_re(r".*train period is .* days.*outdated regimes.*", caplog)
+
+    def test_no_timeframe_detail_warning(self, walkforward_conf, caplog):
+        walkforward_conf.pop("timeframe_detail", None)
+        wf = WalkForward(walkforward_conf)
+        windows = wf._compute_windows()
+        wf._validate(windows)
+        assert log_has_re(r".*No --timeframe-detail.*", caplog)
+
+    def test_high_epochs_warning(self, walkforward_conf, caplog):
+        walkforward_conf["epochs"] = 500
+        wf = WalkForward(walkforward_conf)
+        windows = wf._compute_windows()
+        wf._validate(windows)
+        assert log_has_re(r".*Epochs per window.*300.*per-window overfitting.*", caplog)
+
+
+# ------------------------------------------------------------------
+# Parameter stability analysis
+# ------------------------------------------------------------------
+
+
+class TestParamStability:
+    def test_stable_params(self):
+        all_params = [
+            {"buy": {"rsi": 30, "adx": 25}},
+            {"buy": {"rsi": 31, "adx": 26}},
+            {"buy": {"rsi": 29, "adx": 24}},
+        ]
+        ranges = {"rsi": (10.0, 90.0), "adx": (10.0, 50.0)}
+        result = WalkForward._analyze_param_stability(all_params, ranges)
+
+        assert "rsi" in result
+        assert "adx" in result
+        assert result["rsi"]["stable"] is True
+        assert result["rsi"]["unstable"] is False
+
+    def test_unstable_params(self):
+        all_params = [
+            {"buy": {"rsi": 10}},
+            {"buy": {"rsi": 50}},
+            {"buy": {"rsi": 90}},
+        ]
+        ranges = {"rsi": (10.0, 90.0)}
+        result = WalkForward._analyze_param_stability(all_params, ranges)
+
+        assert result["rsi"]["unstable"] is True
+        assert result["rsi"]["stable"] is False
+
+    def test_missing_range_fallback(self):
+        all_params = [
+            {"buy": {"unknown_param": 100}},
+            {"buy": {"unknown_param": 102}},
+        ]
+        result = WalkForward._analyze_param_stability(all_params, {})
+        assert "unknown_param" in result
+        assert result["unknown_param"]["std_over_range"] >= 0
+
+    def test_single_value_skipped(self):
+        all_params = [
+            {"buy": {"rsi": 30}},
+        ]
+        ranges = {"rsi": (10.0, 90.0)}
+        result = WalkForward._analyze_param_stability(all_params, ranges)
+        assert "rsi" not in result
+
+    def test_non_numeric_skipped(self):
+        all_params = [
+            {"buy": {"method": "sma"}},
+            {"buy": {"method": "ema"}},
+        ]
+        ranges = {}
+        result = WalkForward._analyze_param_stability(all_params, ranges)
+        assert "method" not in result
+
+
+# ------------------------------------------------------------------
+# Consensus params
+# ------------------------------------------------------------------
+
+
+class TestConsensusParams:
+    def test_median_numeric(self):
+        all_params = [
+            {"buy": {"rsi": 30}},
+            {"buy": {"rsi": 40}},
+            {"buy": {"rsi": 50}},
+        ]
+        result = WalkForward._compute_consensus_params(all_params)
+        assert result["buy"]["rsi"] == 40
+
+    def test_median_int_preserved(self):
+        all_params = [
+            {"buy": {"rsi": 30}},
+            {"buy": {"rsi": 40}},
+            {"buy": {"rsi": 50}},
+        ]
+        result = WalkForward._compute_consensus_params(all_params)
+        assert isinstance(result["buy"]["rsi"], int)
+
+    def test_median_float_preserved(self):
+        all_params = [
+            {"buy": {"threshold": 0.1}},
+            {"buy": {"threshold": 0.2}},
+            {"buy": {"threshold": 0.3}},
+        ]
+        result = WalkForward._compute_consensus_params(all_params)
+        assert isinstance(result["buy"]["threshold"], float)
+        assert abs(result["buy"]["threshold"] - 0.2) < 1e-6
+
+    def test_categorical_mode(self):
+        all_params = [
+            {"buy": {"method": "sma"}},
+            {"buy": {"method": "sma"}},
+            {"buy": {"method": "ema"}},
+        ]
+        result = WalkForward._compute_consensus_params(all_params)
+        assert result["buy"]["method"] == "sma"
+
+    def test_multiple_spaces(self):
+        all_params = [
+            {"buy": {"rsi": 30}, "sell": {"profit": 0.01}},
+            {"buy": {"rsi": 40}, "sell": {"profit": 0.02}},
+            {"buy": {"rsi": 50}, "sell": {"profit": 0.03}},
+        ]
+        result = WalkForward._compute_consensus_params(all_params)
+        assert "buy" in result
+        assert "sell" in result
+        assert result["buy"]["rsi"] == 40
+        assert abs(result["sell"]["profit"] - 0.02) < 1e-6
+
+    def test_even_number_of_values(self):
+        all_params = [
+            {"buy": {"rsi": 30}},
+            {"buy": {"rsi": 40}},
+            {"buy": {"rsi": 50}},
+            {"buy": {"rsi": 60}},
+        ]
+        result = WalkForward._compute_consensus_params(all_params)
+        assert result["buy"]["rsi"] == 45
+
+
+# ------------------------------------------------------------------
+# Degradation
+# ------------------------------------------------------------------
+
+
+class TestDegradation:
+    def test_normal_degradation(self):
+        train = {"profit_pct": 10.0, "calmar": 2.0, "sharpe": 1.5, "profit_factor": 2.0}
+        test = {"profit_pct": 5.0, "calmar": 1.0, "sharpe": 0.75, "profit_factor": 1.5}
+        result = WalkForward._compute_degradation(train, test)
+
+        assert result["profit_pct"] == pytest.approx(-0.5, abs=0.01)
+        assert result["calmar"] == pytest.approx(-0.5, abs=0.01)
+
+    def test_zero_train_value(self):
+        train = {"profit_pct": 0.0, "calmar": 0.0, "sharpe": 0.0, "profit_factor": 0.0}
+        test = {"profit_pct": 5.0, "calmar": 1.0, "sharpe": 0.5, "profit_factor": 1.0}
+        result = WalkForward._compute_degradation(train, test)
+
+        for v in result.values():
+            assert v == 0.0
+
+    def test_improvement(self):
+        train = {"profit_pct": 5.0, "calmar": 1.0, "sharpe": 0.5, "profit_factor": 1.0}
+        test = {"profit_pct": 10.0, "calmar": 2.0, "sharpe": 1.0, "profit_factor": 2.0}
+        result = WalkForward._compute_degradation(train, test)
+
+        assert result["profit_pct"] == pytest.approx(1.0, abs=0.01)
+
+
+# ------------------------------------------------------------------
+# Warning flags
+# ------------------------------------------------------------------
+
+
+class TestWarningFlags:
+    def _make_wf(self, conf):
+        return WalkForward(conf)
+
+    def test_low_trade_count_warning(self, walkforward_conf):
+        wf = self._make_wf(walkforward_conf)
+        window = WalkForwardWindow(
+            index=0,
+            train_start=datetime(2018, 1, 1, tzinfo=UTC),
+            train_end=datetime(2018, 6, 1, tzinfo=UTC),
+            test_start=datetime(2018, 6, 8, tzinfo=UTC),
+            test_end=datetime(2018, 9, 1, tzinfo=UTC),
+        )
+        results = [
+            WindowResult(
+                window=window,
+                test_metrics={"trades": 5},
+                test_trade_count=5,
+            )
+        ]
+        warnings = wf._generate_warning_flags(results, {}, 1)
+        assert any("test trades" in w for w in warnings)
+
+    def test_unstable_param_warning(self, walkforward_conf):
+        wf = self._make_wf(walkforward_conf)
+        stability = {
+            "rsi": {"unstable": True, "stable": False},
+        }
+        warnings = wf._generate_warning_flags([], stability, 1)
+        assert any("Unstable" in w for w in warnings)
+
+    def test_no_timeframe_detail_warning(self, walkforward_conf):
+        walkforward_conf.pop("timeframe_detail", None)
+        wf = self._make_wf(walkforward_conf)
+        warnings = wf._generate_warning_flags([], {}, 1)
+        assert any("timeframe-detail" in w for w in warnings)
+
+    def test_meta_overfitting_warning(self, walkforward_conf):
+        wf = self._make_wf(walkforward_conf)
+        warnings = wf._generate_warning_flags([], {}, 3)
+        assert any("run #3" in w for w in warnings)
+
+    def test_no_warnings_clean(self, walkforward_conf):
+        walkforward_conf["timeframe_detail"] = "1m"
+        wf = self._make_wf(walkforward_conf)
+        window = WalkForwardWindow(
+            index=0,
+            train_start=datetime(2018, 1, 1, tzinfo=UTC),
+            train_end=datetime(2018, 6, 1, tzinfo=UTC),
+            test_start=datetime(2018, 6, 8, tzinfo=UTC),
+            test_end=datetime(2018, 9, 1, tzinfo=UTC),
+        )
+        results = [
+            WindowResult(
+                window=window,
+                test_metrics={"trades": 100},
+                test_trade_count=100,
+            )
+        ]
+        warnings = wf._generate_warning_flags(results, {}, 1)
+        assert len(warnings) == 0
+
+
+# ------------------------------------------------------------------
+# Window dataclass helpers
+# ------------------------------------------------------------------
+
+
+class TestWalkForwardWindow:
+    def test_train_timerange_str(self):
+        w = WalkForwardWindow(
+            index=0,
+            train_start=datetime(2018, 1, 1, tzinfo=UTC),
+            train_end=datetime(2018, 6, 1, tzinfo=UTC),
+            test_start=datetime(2018, 6, 8, tzinfo=UTC),
+            test_end=datetime(2018, 9, 1, tzinfo=UTC),
+        )
+        assert w.train_timerange_str() == "20180101-20180601"
+
+    def test_test_timerange_str(self):
+        w = WalkForwardWindow(
+            index=0,
+            train_start=datetime(2018, 1, 1, tzinfo=UTC),
+            train_end=datetime(2018, 6, 1, tzinfo=UTC),
+            test_start=datetime(2018, 6, 8, tzinfo=UTC),
+            test_end=datetime(2018, 9, 1, tzinfo=UTC),
+        )
+        assert w.test_timerange_str() == "20180608-20180901"
+
+
+# ------------------------------------------------------------------
+# Extract metrics
+# ------------------------------------------------------------------
+
+
+class TestExtractMetrics:
+    def test_extract_full_metrics(self, walkforward_conf):
+        wf = WalkForward(walkforward_conf)
+        strat_data = {
+            "profit_total": 0.15,
+            "profit_total_abs": 150.0,
+            "total_trades": 42,
+            "calmar": 2.1,
+            "sharpe": 1.5,
+            "sortino": 2.0,
+            "max_drawdown_account": 0.08,
+            "profit_factor": 1.8,
+            "winrate": 0.65,
+            "holding_avg": "1:30:00",
+        }
+        result = wf._extract_metrics(strat_data)
+
+        assert result["profit_pct"] == pytest.approx(15.0)
+        assert result["trades"] == 42
+        assert result["calmar"] == 2.1
+        assert result["max_dd_pct"] == pytest.approx(8.0)
+
+    def test_extract_missing_keys(self, walkforward_conf):
+        wf = WalkForward(walkforward_conf)
+        result = wf._extract_metrics({})
+
+        assert result["profit_pct"] == 0
+        assert result["trades"] == 0
+        assert result["calmar"] == 0
+
+
+# ------------------------------------------------------------------
+# Export / persistence
+# ------------------------------------------------------------------
+
+
+class TestExport:
+    def test_export_consensus_json(self, walkforward_conf, tmp_path):
+        wf = WalkForward(walkforward_conf)
+        consensus = {
+            "buy": {"rsi": 35, "adx": 25},
+            "sell": {"profit": 0.02},
+        }
+        path = wf._export_consensus_json(consensus, None)
+        assert path.exists()
+
+        with path.open("r") as f:
+            data = rapidjson.load(f)
+        assert data["strategy_name"] == "HyperoptableStrategy"
+        assert data["params"]["buy"]["rsi"] == 35
+
+    def test_export_consensus_to_strategy_json(self, walkforward_conf, tmp_path):
+        strategy_json = tmp_path / "HyperoptableStrategy.json"
+        wf = WalkForward(walkforward_conf)
+        consensus = {"buy": {"rsi": 35}}
+        wf._export_consensus_json(consensus, strategy_json)
+
+        assert strategy_json.exists()
+        with strategy_json.open("r") as f:
+            data = rapidjson.load(f)
+        assert data["params"]["buy"]["rsi"] == 35
+
+    def test_export_results_json(self, walkforward_conf, tmp_path):
+        wf = WalkForward(walkforward_conf)
+        window = WalkForwardWindow(
+            index=0,
+            train_start=datetime(2018, 1, 1, tzinfo=UTC),
+            train_end=datetime(2018, 6, 1, tzinfo=UTC),
+            test_start=datetime(2018, 6, 8, tzinfo=UTC),
+            test_end=datetime(2018, 9, 1, tzinfo=UTC),
+        )
+        results = [
+            WindowResult(
+                window=window,
+                train_metrics={"profit_pct": 10},
+                test_metrics={"profit_pct": 5},
+            )
+        ]
+        path = wf._export_results_json(results, {}, {"buy": {"rsi": 30}})
+        assert path.exists()
+
+        with path.open("r") as f:
+            data = rapidjson.load(f)
+        assert data["strategy"] == "HyperoptableStrategy"
+        assert len(data["windows"]) == 1
+        assert data["consensus_params"]["buy"]["rsi"] == 30
+
+    def test_log_wfa_run_appends(self, walkforward_conf, tmp_path):
+        wf = WalkForward(walkforward_conf)
+        window = WalkForwardWindow(
+            index=0,
+            train_start=datetime(2018, 1, 1, tzinfo=UTC),
+            train_end=datetime(2018, 6, 1, tzinfo=UTC),
+            test_start=datetime(2018, 6, 8, tzinfo=UTC),
+            test_end=datetime(2018, 9, 1, tzinfo=UTC),
+        )
+        results = [
+            WindowResult(
+                window=window,
+                test_metrics={"profit_pct": 5},
+                test_trade_count=10,
+            )
+        ]
+        stability = {"rsi": {"stable": True}}
+
+        count1 = wf._log_wfa_run(results, stability)
+        assert count1 == 1
+
+        count2 = wf._log_wfa_run(results, stability)
+        assert count2 == 2
+
+        log_file = tmp_path / "walk_forward" / "wfa_log.jsonl"
+        assert log_file.exists()
+        lines = [line for line in log_file.read_text().splitlines() if line.strip()]
+        assert len(lines) == 2
+
+
+# ------------------------------------------------------------------
+# Strategy JSON helpers
+# ------------------------------------------------------------------
+
+
+class TestStrategyJsonHelpers:
+    def test_delete_strategy_json(self, walkforward_conf, tmp_path, caplog):
+        json_path = tmp_path / "test.json"
+        json_path.write_text("{}")
+        wf = WalkForward(walkforward_conf)
+        wf._delete_strategy_json(json_path)
+        assert not json_path.exists()
+        assert log_has(f"Deleted co-located JSON: {json_path}", caplog)
+
+    def test_delete_nonexistent_json(self, walkforward_conf, tmp_path):
+        json_path = tmp_path / "nonexistent.json"
+        wf = WalkForward(walkforward_conf)
+        wf._delete_strategy_json(json_path)
+
+    def test_delete_none_json(self, walkforward_conf):
+        wf = WalkForward(walkforward_conf)
+        wf._delete_strategy_json(None)
+
+    def test_save_window_params(self, walkforward_conf, tmp_path):
+        json_path = tmp_path / "strategy.json"
+        params_data = {
+            "strategy_name": "test",
+            "params": {"buy": {"rsi": 30}},
+            "ft_stratparam_v": 1,
+        }
+        with json_path.open("w") as f:
+            rapidjson.dump(params_data, f)
+
+        wf = WalkForward(walkforward_conf)
+        result = wf._save_window_params(0, json_path)
+
+        assert result == {"buy": {"rsi": 30}}
+        saved = tmp_path / "walk_forward" / "window_0_params.json"
+        assert saved.exists()
+
+    def test_restore_params(self, walkforward_conf, tmp_path):
+        json_path = tmp_path / "strategy.json"
+        wf = WalkForward(walkforward_conf)
+        wf._restore_params({"buy": {"rsi": 30}}, json_path)
+
+        assert json_path.exists()
+        with json_path.open("r") as f:
+            data = rapidjson.load(f)
+        assert data["params"]["buy"]["rsi"] == 30
+        assert data["strategy_name"] == "HyperoptableStrategy"
+
+
+# ------------------------------------------------------------------
+# Lock file
+# ------------------------------------------------------------------
+
+
+class TestLockFile:
+    def test_get_lock_filename(self, walkforward_conf, tmp_path):
+        path = WalkForward.get_lock_filename(walkforward_conf)
+        assert "walk_forward.lock" in path
+        assert str(tmp_path) in path
+
+
+# ------------------------------------------------------------------
+# Report formatting (smoke test)
+# ------------------------------------------------------------------
+
+
+class TestFormatReport:
+    def test_format_report_logs(self, walkforward_conf, caplog):
+        wf = WalkForward(walkforward_conf)
+        window = WalkForwardWindow(
+            index=0,
+            train_start=datetime(2018, 1, 1, tzinfo=UTC),
+            train_end=datetime(2018, 6, 1, tzinfo=UTC),
+            test_start=datetime(2018, 6, 8, tzinfo=UTC),
+            test_end=datetime(2018, 9, 1, tzinfo=UTC),
+        )
+        results = [
+            WindowResult(
+                window=window,
+                train_metrics={"profit_pct": 10, "calmar": 2, "max_dd_pct": 5, "trades": 50},
+                test_metrics={"profit_pct": 5, "calmar": 1, "max_dd_pct": 8, "trades": 30},
+                baseline_metrics={"profit_pct": 3, "calmar": 0.5, "max_dd_pct": 10, "trades": 25},
+            )
+        ]
+        stability = {
+            "rsi": {
+                "median": 30.0,
+                "std_over_range": 0.1,
+                "stable": True,
+                "unstable": False,
+                "values": [29, 30, 31],
+            }
+        }
+        consensus = {"buy": {"rsi": 30}}
+
+        with caplog.at_level("INFO"):
+            wf._format_report(results, stability, consensus, ["test warning"])
+
+        assert log_has_re(r".*Walk-Forward Analysis Results.*", caplog)
+        assert log_has_re(r".*PARAMETER STABILITY.*", caplog)
+        assert log_has_re(r".*CONSENSUS PARAMS.*", caplog)
+        assert log_has_re(r".*WARNING FLAGS.*", caplog)
+        assert log_has_re(r".*test warning.*", caplog)
+
+
+# ------------------------------------------------------------------
+# CLI command tests
+# ------------------------------------------------------------------
+
+
+class TestStartWalkForward:
+    def test_start_walk_forward_missing_deps(self, mocker, walkforward_conf, caplog):
+        mocker.patch(
+            "freqtrade.commands.walk_forward_commands.start_walk_forward",
+            side_effect=OperationalException(
+                "No module named 'filelock'. "
+                "Please ensure that the hyperopt dependencies are installed."
+            ),
+        )
+
+    def test_start_filelock(self, mocker, walkforward_conf, caplog):
+        hyperopt_mock = MagicMock(
+            side_effect=Timeout(WalkForward.get_lock_filename(walkforward_conf))
+        )
+        patched_configuration_load_config_file(mocker, walkforward_conf)
+        mocker.patch(
+            "freqtrade.optimize.walk_forward.WalkForward.__init__",
+            hyperopt_mock,
+        )
+        patch_exchange(mocker)
+
+        args = [
+            "walk-forward",
+            "--config",
+            "config.json",
+            "--strategy",
+            "HyperoptableStrategy",
+            "--hyperopt-loss",
+            "SharpeHyperOptLossDaily",
+            "--epochs",
+            "5",
+            "--timerange",
+            "20180101-20200101",
+        ]
+        pargs = get_args(args)
+        start_walk_forward(pargs)
+        assert log_has(
+            "Another running instance of freqtrade Walk-Forward detected.",
+            caplog,
+        )
+
+    def test_walk_forward_cli_args_parsed(self):
+        args = get_args(
+            [
+                "walk-forward",
+                "--config",
+                "config.json",
+                "--strategy",
+                "TestStrategy",
+                "--hyperopt-loss",
+                "SharpeHyperOptLossDaily",
+                "--timerange",
+                "20180101-20200101",
+                "--wf-windows",
+                "7",
+                "--wf-train-ratio",
+                "0.8",
+                "--wf-embargo-days",
+                "14",
+                "--wf-holdout-months",
+                "3",
+                "--wf-min-test-trades",
+                "50",
+            ]
+        )
+        assert args["wf_windows"] == 7
+        assert args["wf_train_ratio"] == 0.8
+        assert args["wf_embargo_days"] == 14
+        assert args["wf_holdout_months"] == 3
+        assert args["wf_min_test_trades"] == 50
+
+    def test_walk_forward_cli_defaults(self):
+        args = get_args(
+            [
+                "walk-forward",
+                "--config",
+                "config.json",
+                "--strategy",
+                "TestStrategy",
+                "--hyperopt-loss",
+                "SharpeHyperOptLossDaily",
+                "--timerange",
+                "20180101-20200101",
+            ]
+        )
+        assert args["wf_windows"] == 5
+        assert args["wf_train_ratio"] == 0.75
+        assert args["wf_embargo_days"] == 7
+        assert args["wf_holdout_months"] == 0
+        assert args["wf_min_test_trades"] == 30
+
+
+# ------------------------------------------------------------------
+# Initialization
+# ------------------------------------------------------------------
+
+
+class TestInit:
+    def test_creates_wfa_dir(self, walkforward_conf, tmp_path):
+        WalkForward(walkforward_conf)
+        assert (tmp_path / "walk_forward").is_dir()
+
+    def test_config_mapping(self, walkforward_conf):
+        wf = WalkForward(walkforward_conf)
+        assert wf.n_windows == 3
+        assert wf.train_ratio == 0.75
+        assert wf.embargo_days == 7
+        assert wf.holdout_months == 0
+        assert wf.min_test_trades == 30
+        assert wf.strategy_name == "HyperoptableStrategy"

--- a/tests/optimize/test_walk_forward.py
+++ b/tests/optimize/test_walk_forward.py
@@ -507,7 +507,7 @@ class TestExport:
             "buy": {"rsi": 35, "adx": 25},
             "sell": {"profit": 0.02},
         }
-        path = wf._export_consensus_json(consensus, None)
+        path = wf._export_consensus_json(consensus)
         assert path.exists()
 
         with path.open("r") as f:
@@ -515,16 +515,13 @@ class TestExport:
         assert data["strategy_name"] == "HyperoptableStrategy"
         assert data["params"]["buy"]["rsi"] == 35
 
-    def test_export_consensus_to_strategy_json(self, walkforward_conf, tmp_path):
+    def test_export_consensus_does_not_write_strategy_json(self, walkforward_conf, tmp_path):
         strategy_json = tmp_path / "HyperoptableStrategy.json"
         wf = WalkForward(walkforward_conf)
         consensus = {"buy": {"rsi": 35}}
-        wf._export_consensus_json(consensus, strategy_json)
+        wf._export_consensus_json(consensus)
 
-        assert strategy_json.exists()
-        with strategy_json.open("r") as f:
-            data = rapidjson.load(f)
-        assert data["params"]["buy"]["rsi"] == 35
+        assert not strategy_json.exists()
 
     def test_export_results_json(self, walkforward_conf, tmp_path):
         wf = WalkForward(walkforward_conf)
@@ -631,6 +628,22 @@ class TestStrategyJsonHelpers:
             data = rapidjson.load(f)
         assert data["params"]["buy"]["rsi"] == 30
         assert data["strategy_name"] == "HyperoptableStrategy"
+
+    def test_restore_original_json_restores_content(self, tmp_path):
+        json_path = tmp_path / "strategy.json"
+        original = b'{"original": true}'
+        json_path.write_text("overwritten")
+        WalkForward._restore_original_json(json_path, original)
+        assert json_path.read_bytes() == original
+
+    def test_restore_original_json_removes_if_none_existed(self, tmp_path):
+        json_path = tmp_path / "strategy.json"
+        json_path.write_text("should be removed")
+        WalkForward._restore_original_json(json_path, None)
+        assert not json_path.exists()
+
+    def test_restore_original_json_noop_if_no_path(self):
+        WalkForward._restore_original_json(None, None)
 
 
 # ------------------------------------------------------------------
@@ -804,3 +817,409 @@ class TestInit:
         assert wf.holdout_months == 0
         assert wf.min_test_trades == 30
         assert wf.strategy_name == "HyperoptableStrategy"
+
+
+# ------------------------------------------------------------------
+# WFA Dashboard
+# ------------------------------------------------------------------
+
+
+class TestWFADashboard:
+    @staticmethod
+    def _make_windows():
+        return [
+            WalkForwardWindow(
+                index=0,
+                train_start=datetime(2025, 1, 1, tzinfo=UTC),
+                train_end=datetime(2025, 4, 1, tzinfo=UTC),
+                test_start=datetime(2025, 4, 8, tzinfo=UTC),
+                test_end=datetime(2025, 5, 8, tzinfo=UTC),
+            ),
+            WalkForwardWindow(
+                index=1,
+                train_start=datetime(2025, 2, 8, tzinfo=UTC),
+                train_end=datetime(2025, 5, 8, tzinfo=UTC),
+                test_start=datetime(2025, 5, 15, tzinfo=UTC),
+                test_end=datetime(2025, 6, 15, tzinfo=UTC),
+            ),
+        ]
+
+    def test_dashboard_init(self):
+        from freqtrade.optimize.wfa_output import WFADashboard
+
+        windows = self._make_windows()
+        dash = WFADashboard(windows, "TestStrat", 200, "USDC")
+        assert dash._n_windows == 2
+        assert dash._strategy == "TestStrat"
+        assert dash._epochs == 200
+
+    def test_set_window_resets_state(self):
+        from freqtrade.optimize.wfa_output import WFADashboard
+
+        windows = self._make_windows()
+        dash = WFADashboard(windows, "TestStrat", 200, "USDC")
+        dash._ho_epoch = 50
+        dash._ho_best = {"loss": 0.5}
+        dash.set_window(windows[1])
+        assert dash._current_idx == 1
+        assert dash._ho_epoch == 0
+        assert dash._ho_best is None
+        assert dash._phase_log[1]["hyperopt"] == "active"
+
+    def test_set_phase_transitions(self):
+        from freqtrade.optimize.wfa_output import WFADashboard
+
+        windows = self._make_windows()
+        dash = WFADashboard(windows, "TestStrat", 200, "USDC")
+        dash.set_window(windows[0])
+        dash.set_phase("backtest_optimized")
+        assert dash._phase_log[0]["hyperopt"] == "done"
+        assert dash._phase_log[0]["backtest_optimized"] == "active"
+
+    def test_on_epoch_updates_best(self):
+        from freqtrade.optimize.wfa_output import WFADashboard
+
+        windows = self._make_windows()
+        dash = WFADashboard(windows, "TestStrat", 200, "USDC")
+        dash.on_epoch({"current_epoch": 10, "is_best": False, "loss": 0.5})
+        assert dash._ho_epoch == 10
+        assert dash._ho_best is None
+
+        dash.on_epoch({"current_epoch": 15, "is_best": True, "loss": 0.3})
+        assert dash._ho_epoch == 15
+        assert dash._ho_best["loss"] == 0.3
+
+    def test_complete_window(self):
+        from freqtrade.optimize.wfa_output import WFADashboard
+
+        windows = self._make_windows()
+        dash = WFADashboard(windows, "TestStrat", 200, "USDC")
+        dash.set_window(windows[0])
+        result = WindowResult(
+            window=windows[0],
+            test_metrics={"profit_pct": 12.5, "trades": 100},
+        )
+        dash.complete_window(result)
+        assert len(dash._completed) == 1
+        assert all(v == "done" for v in dash._phase_log[0].values())
+
+    def test_build_renders_without_error(self):
+        from freqtrade.optimize.wfa_output import WFADashboard
+
+        windows = self._make_windows()
+        dash = WFADashboard(windows, "TestStrat", 200, "USDC")
+        dash.set_window(windows[0])
+        dash.on_epoch({
+            "current_epoch": 50,
+            "is_best": True,
+            "loss": -0.95,
+            "results_metrics": {
+                "profit_total": 0.25,
+                "total_trades": 150,
+                "max_drawdown_account": 0.05,
+            },
+        })
+        panel = dash._build()
+        assert panel is not None
+
+    def test_build_with_completed_windows(self):
+        from freqtrade.optimize.wfa_output import WFADashboard
+
+        windows = self._make_windows()
+        dash = WFADashboard(windows, "TestStrat", 200, "USDC")
+        dash.set_window(windows[0])
+        dash.complete_window(WindowResult(
+            window=windows[0],
+            test_metrics={"profit_pct": 10, "trades": 80, "calmar": 1.5, "max_dd_pct": 5},
+            baseline_metrics={"profit_pct": 5},
+        ))
+        dash.set_window(windows[1])
+        dash.set_phase("backtest_optimized")
+        panel = dash._build()
+        assert panel is not None
+
+    def test_build_with_market_context_and_hhi(self):
+        from freqtrade.optimize.wfa_output import WFADashboard
+
+        windows = self._make_windows()
+        dash = WFADashboard(windows, "TestStrat", 200, "USDC")
+        dash.set_window(windows[0])
+        dash.complete_window(WindowResult(
+            window=windows[0],
+            test_metrics={
+                "profit_pct": 10, "trades": 80,
+                "calmar": 1.5, "max_dd_pct": 5,
+                "hhi": 0.12, "top1_pct": 30,
+            },
+            baseline_metrics={"profit_pct": 5},
+            market_context={
+                "btc_change_pct": 15.2,
+                "atr_pct": 3.1,
+                "volatility_ann_pct": 60,
+                "regime": "bull",
+            },
+        ))
+        panel = dash._build()
+        assert panel is not None
+
+    def test_insights_panel_renders(self):
+        from freqtrade.optimize.wfa_output import WFADashboard
+
+        windows = self._make_windows()
+        dash = WFADashboard(windows, "TestStrat", 200, "USDC")
+        for i, w in enumerate(windows):
+            dash.set_window(w)
+            dash.complete_window(WindowResult(
+                window=w,
+                test_metrics={
+                    "profit_pct": 5 + i * 3, "trades": 60 + i * 10,
+                    "calmar": 1.0 + i * 0.5, "max_dd_pct": 8 - i,
+                    "hhi": 0.05, "top1_pct": 15,
+                },
+                baseline_metrics={"profit_pct": 2},
+                market_context={"regime": "range"},
+                params={"buy": {"rsi_low": 25 + i, "vol_mult": 1.5 + i * 0.1}},
+            ))
+        panel = dash._build()
+        assert panel is not None
+        insights = dash._build_insights()
+        assert insights is not None
+
+    def test_insights_with_one_window(self):
+        from freqtrade.optimize.wfa_output import WFADashboard
+
+        windows = self._make_windows()
+        dash = WFADashboard(windows, "TestStrat", 200, "USDC")
+        dash.set_window(windows[0])
+        dash.complete_window(WindowResult(
+            window=windows[0],
+            test_metrics={"profit_pct": -5, "trades": 30, "calmar": -0.5,
+                          "max_dd_pct": 15, "hhi": 0.25},
+            baseline_metrics={"profit_pct": 2},
+            params={"buy": {"rsi_low": 30}},
+        ))
+        insights = dash._build_insights()
+        assert insights is not None
+
+
+# ------------------------------------------------------------------
+# Anchored window mode (Improvement #1)
+# ------------------------------------------------------------------
+
+
+class TestAnchoredWindows:
+    def test_anchored_windows_basic(self, walkforward_conf):
+        walkforward_conf["wf_mode"] = "anchored"
+        wf = WalkForward(walkforward_conf)
+        windows = wf._compute_windows()
+
+        assert len(windows) == 3
+        for w in windows:
+            assert w.train_start == windows[0].train_start
+        for w in windows:
+            assert w.train_start < w.train_end
+            assert w.test_start < w.test_end
+
+    def test_anchored_train_grows(self, walkforward_conf):
+        walkforward_conf["wf_mode"] = "anchored"
+        wf = WalkForward(walkforward_conf)
+        windows = wf._compute_windows()
+
+        for i in range(len(windows) - 1):
+            days_i = (windows[i].train_end - windows[i].train_start).days
+            days_j = (windows[i + 1].train_end - windows[i + 1].train_start).days
+            assert days_j > days_i
+
+    def test_anchored_disjoint_tests(self, walkforward_conf):
+        walkforward_conf["wf_mode"] = "anchored"
+        wf = WalkForward(walkforward_conf)
+        windows = wf._compute_windows()
+
+        for i in range(len(windows) - 1):
+            assert windows[i].test_end <= windows[i + 1].test_start
+
+    def test_anchored_embargo(self, walkforward_conf):
+        walkforward_conf["wf_mode"] = "anchored"
+        wf = WalkForward(walkforward_conf)
+        windows = wf._compute_windows()
+
+        for w in windows:
+            gap = (w.test_start - w.train_end).days
+            assert gap == walkforward_conf["wf_embargo_days"]
+
+    def test_anchored_too_many_windows_raises(self, walkforward_conf):
+        walkforward_conf["wf_mode"] = "anchored"
+        walkforward_conf["wf_windows"] = 50
+        wf = WalkForward(walkforward_conf)
+        with pytest.raises(OperationalException, match=r"window too short"):
+            wf._compute_windows()
+
+    def test_rolling_mode_is_default(self, walkforward_conf):
+        wf = WalkForward(walkforward_conf)
+        assert wf.wf_mode == "rolling"
+
+
+# ------------------------------------------------------------------
+# Concentrated profit check (Improvement #3)
+# ------------------------------------------------------------------
+
+
+class TestConcentration:
+    def test_compute_concentration_basic(self):
+        profits = [100, 50, 30, 20]
+        result = WalkForward._compute_concentration(profits)
+        assert "hhi" in result
+        assert "top1_pct" in result
+        assert result["hhi"] > 0
+        assert result["top1_pct"] == 50.0
+
+    def test_compute_concentration_single_trade(self):
+        result = WalkForward._compute_concentration([100.0])
+        assert result["hhi"] == 1.0
+        assert result["top1_pct"] == 100.0
+
+    def test_compute_concentration_empty(self):
+        result = WalkForward._compute_concentration([])
+        assert result["hhi"] == 0.0
+        assert result["top1_pct"] == 0.0
+
+    def test_compute_concentration_mixed_signs(self):
+        profits = [100, -50, 30, -20]
+        result = WalkForward._compute_concentration(profits)
+        assert result["hhi"] > 0
+        assert result["top1_pct"] > 0
+
+    def test_hhi_perfectly_diversified(self):
+        profits = [10.0] * 100
+        result = WalkForward._compute_concentration(profits)
+        assert result["hhi"] == pytest.approx(0.01, abs=0.001)
+
+
+# ------------------------------------------------------------------
+# Weighted consensus (Improvement #4)
+# ------------------------------------------------------------------
+
+
+class TestWeightedConsensus:
+    def test_unweighted_consensus(self):
+        params = [
+            {"buy": {"a": 10, "b": 1.0}},
+            {"buy": {"a": 20, "b": 2.0}},
+            {"buy": {"a": 30, "b": 3.0}},
+        ]
+        c = WalkForward._compute_consensus_params(params)
+        assert c["buy"]["a"] == 20
+        assert c["buy"]["b"] == 2.0
+
+    def test_weighted_consensus_skews(self):
+        params = [
+            {"buy": {"a": 10}},
+            {"buy": {"a": 20}},
+            {"buy": {"a": 30}},
+        ]
+        weights = [0.1, 0.1, 10.0]
+        c = WalkForward._compute_consensus_params(params, weights=weights)
+        assert c["buy"]["a"] == 30
+
+    def test_weighted_consensus_equal_weights(self):
+        params = [
+            {"buy": {"a": 10.0}},
+            {"buy": {"a": 20.0}},
+            {"buy": {"a": 30.0}},
+        ]
+        weights = [1.0, 1.0, 1.0]
+        c = WalkForward._compute_consensus_params(params, weights=weights)
+        assert c["buy"]["a"] == 20.0
+
+    def test_weighted_median_basic(self):
+        med = WalkForward._weighted_median(
+            [1.0, 2.0, 3.0], [1.0, 1.0, 1.0]
+        )
+        assert med == 2.0
+
+    def test_weighted_median_heavy_last(self):
+        med = WalkForward._weighted_median(
+            [1.0, 2.0, 3.0], [0.1, 0.1, 10.0]
+        )
+        assert med == 3.0
+
+
+# ------------------------------------------------------------------
+# Deflated Sharpe Ratio (Improvement #5)
+# ------------------------------------------------------------------
+
+
+class TestDeflatedSharpe:
+    def test_dsr_high_sr_few_trials(self):
+        dsr = WalkForward._deflated_sharpe_ratio(
+            sr_observed=3.0, n_trials=10, n_obs=252
+        )
+        assert 0 < dsr <= 1
+
+    def test_dsr_low_sr_many_trials(self):
+        dsr = WalkForward._deflated_sharpe_ratio(
+            sr_observed=0.5, n_trials=1000, n_obs=100
+        )
+        assert dsr < 0.5
+
+    def test_dsr_zero_sr(self):
+        dsr = WalkForward._deflated_sharpe_ratio(
+            sr_observed=0.0, n_trials=100, n_obs=252
+        )
+        assert dsr < 0.5
+
+    def test_dsr_edge_cases(self):
+        assert WalkForward._deflated_sharpe_ratio(1.0, 1, 100) == 0.0
+        assert WalkForward._deflated_sharpe_ratio(1.0, 10, 1) == 0.0
+
+    def test_dsr_increases_with_sr(self):
+        dsr_low = WalkForward._deflated_sharpe_ratio(0.5, 100, 252)
+        dsr_high = WalkForward._deflated_sharpe_ratio(3.0, 100, 252)
+        assert dsr_high > dsr_low
+
+    def test_dsr_decreases_with_more_trials(self):
+        dsr_few = WalkForward._deflated_sharpe_ratio(2.0, 10, 252)
+        dsr_many = WalkForward._deflated_sharpe_ratio(2.0, 10000, 252)
+        assert dsr_few > dsr_many
+
+    def test_norm_cdf_basic(self):
+        assert WalkForward._norm_cdf(0) == pytest.approx(0.5, abs=0.001)
+        assert WalkForward._norm_cdf(10) > 0.99
+        assert WalkForward._norm_cdf(-10) < 0.01
+
+
+# ------------------------------------------------------------------
+# Market context (Improvement #2)
+# ------------------------------------------------------------------
+
+
+class TestMarketContext:
+    def test_market_context_graceful_failure(self, walkforward_conf):
+        """Should return empty dict if BTC data not available."""
+        wf = WalkForward(walkforward_conf)
+        ctx = wf._compute_market_context(
+            datetime(2019, 1, 1, tzinfo=UTC),
+            datetime(2019, 3, 1, tzinfo=UTC),
+        )
+        assert isinstance(ctx, dict)
+
+    def test_concentration_in_warning_flags(self, walkforward_conf):
+        wf = WalkForward(walkforward_conf)
+        results = [
+            WindowResult(
+                window=WalkForwardWindow(
+                    index=0,
+                    train_start=datetime(2018, 1, 1, tzinfo=UTC),
+                    train_end=datetime(2018, 6, 1, tzinfo=UTC),
+                    test_start=datetime(2018, 6, 8, tzinfo=UTC),
+                    test_end=datetime(2018, 8, 1, tzinfo=UTC),
+                ),
+                test_metrics={
+                    "trades": 50, "top1_pct": 60, "hhi": 0.2,
+                },
+                test_trade_count=50,
+            ),
+        ]
+        warnings = wf._generate_warning_flags(results, {}, 1)
+        assert any("top-1" in w for w in warnings)
+        assert any("HHI" in w for w in warnings)


### PR DESCRIPTION
## Summary

- Full Walk-Forward Analysis CLI command with **live Rich dashboard** (alternate screen mode)
- **5 professional-grade improvements**: anchored windows, market context, profit concentration check, weighted consensus, deflated Sharpe ratio
- Live **Insights panel** showing emerging verdict, params stability, and alerts as windows complete
- 97 tests covering all components

## What's new since initial implementation

### Live Dashboard (`wfa_output.py`)
Full-screen Rich Live dashboard (`screen=True`) that replaces individual hyperopt/backtest output:
- **Header**: current window, phase, elapsed timer (auto-updates)
- **Progress bar**: hyperopt epoch progress with best result metrics
- **Pipeline**: visual status per window (Hyperopt → BT optim → BT base)
- **Completed table**: profit, trades, Calmar, DD, HHI concentration, market regime, baseline
- **Insights panel** (appears after 1st window): running verdict, avg metrics, beats-baseline count, concentration alerts, emerging consensus params with stability indicators

Render isolation: OS-level fd redirect (stdout/stderr → `/dev/null`) + alternate screen buffer. Zero duplication regardless of library output (optuna, tvDatafeed, joblib, etc.)

### 5 Pro Improvements

#### 1. Rolling/Anchored Windows (`--wf-mode`)
```bash
--wf-mode rolling    # (default) fixed-size sliding train windows
--wf-mode anchored   # train always starts at beginning, grows for each window
```
Anchored mode gives later windows more training data, useful for strategies that benefit from larger sample sizes.

#### 2. Market Context
Each test window automatically computes (from BTC daily data):
- BTC price change (%)
- ATR as % of price
- Annualized volatility
- Regime label (bull / bear / range)

Helps contextualize whether a window's performance was due to the strategy or the market.

#### 3. Concentrated Profit Check
Per-trade profit data extracted from backtest results:
- **HHI** (Herfindahl-Hirschman Index): measures profit concentration across trades
- **Top-1 %**: what % of total profit comes from the single best trade

Warning flags fire when HHI > 0.15 or top-1 > 50% — signals that results depend on a few lucky trades.

#### 4. Weighted Consensus Params
Consensus parameters now use **weighted median** instead of simple median, weighted by each window's test-period Calmar ratio. Windows with better risk-adjusted out-of-sample performance have more influence on the final params.

#### 5. Deflated Sharpe Ratio (Bailey & Lopez de Prado 2014)
Corrects the observed Sharpe ratio for the number of trials (epochs × windows). Reports:
- DSR p-value (probability the observed SR is statistically significant)
- Significance label: significant (>0.95), weak (>0.5), not significant
- Total trial count used for correction

## How it works

### Window layout — Rolling mode (default)
```
Timeline: Jan 2023 ──────────────────────────────────────── Jan 2026

Window 1: ████ TRAIN ████ ░░░ ▓▓ TEST ▓▓
Window 2:      ████ TRAIN ████ ░░░ ▓▓ TEST ▓▓
Window 3:           ████ TRAIN ████ ░░░ ▓▓ TEST ▓▓

████ = Training (hyperopt)   ░░░ = Embargo   ▓▓ = Testing (backtest)
```

### Window layout — Anchored mode
```
Window 1: ████████ TRAIN ████████ ░░░ ▓▓ TEST ▓▓
Window 2: ████████████████ TRAIN ████████████████ ░░░ ▓▓ TEST ▓▓
Window 3: ████████████████████████ TRAIN ████████████████████████ ░░░ ▓▓ TEST ▓▓

Train always starts at the beginning → grows with each window
```

### Per-window cycle
```
For each window:
  1. Delete Strategy.json (clean slate)
  2. HYPEROPT on train period → find best params
  3. BACKTEST on test period with optimized params
  4. BACKTEST on test period with baseline (original) params
  5. Compute market context (BTC data)
  6. Record: metrics, params, concentration, market context
```

### Post-analysis
```
All windows → Weighted consensus params (median by Calmar weight)
All windows → Parameter stability analysis (std / search_range)
All windows → Deflated Sharpe Ratio (multiple-testing correction)
All windows → Warning flags (low trades, concentration, unstable params)
Consensus  → Holdout backtest (if --wf-holdout-months set)
Everything → Full JSON export + console report
```

### File output
```
user_data/walk_forward/
├── window_0_params.json
├── window_1_params.json
├── Strategy_consensus_2026-04-28.json    ← weighted median params
├── Strategy_wfa_results_2026-04-28.json  ← full report with DSR
└── wfa_log.jsonl                         ← meta-overfitting log
```

## CLI options

```bash
freqtrade walk-forward \
    --strategy MyStrategy \
    --hyperopt-loss CalmarHyperOptLoss \
    --timerange 20230101-20260101 \
    --wf-windows 5 \
    --wf-train-ratio 0.75 \
    --wf-embargo-days 7 \
    --wf-holdout-months 3 \
    --wf-min-test-trades 30 \
    --wf-mode anchored \       # NEW
    --epochs 150 \
    --spaces buy sell
```

## Safety

- **Live JSON protection**: original strategy JSON is backed up before WFA starts, restored in a `finally` block (even on Ctrl+C or crash). WFA never overwrites the live strategy JSON — consensus is exported to `walk_forward/` directory only.
- **Filelock**: prevents concurrent WFA runs on the same strategy.

## Tests (97 total)

| Category | Tests |
|----------|-------|
| Window computation (rolling) | 10 |
| Anchored windows | 6 |
| Timerange parsing | 4 |
| Validation | 5 |
| Param stability | 5 |
| Consensus (weighted + unweighted) | 11 |
| Degradation | 3 |
| Concentration (HHI) | 5 |
| Deflated Sharpe Ratio | 7 |
| Market context | 2 |
| Warning flags | 5 |
| Export/persistence | 4 |
| CLI | 4 |
| JSON safety | 3 |
| Dashboard | 10 |
| Helpers | 7 |

## Test plan

- [x] `ruff check` passes on all modified files
- [x] 97 tests pass
- [x] Live dashboard renders correctly (screen=True, no duplication)
- [x] End-to-end run on HippoDCA_hyp_dynv1_casino_v11
- [x] Ctrl+C gracefully restores strategy JSON
- [ ] Full run with holdout to verify holdout path
- [ ] Test anchored mode end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)