### PR TITLE
feat: add MoutonMeanRev & MoutonMomentum hyperopt losses

### DIFF
--- a/.claude-tips/hyperopt.md
+++ b/.claude-tips/hyperopt.md
@@ -24,16 +24,41 @@ Pour la méthodologie staged, voir [HYPEROPT_PLAYBOOK.md](../HYPEROPT_PLAYBOOK.m
 
 ## Loss function — choix par stratégie
 
+### Loss functions custom du fork
+
+| Comportement stratégie | Loss function | Métriques clés |
+|---|---|---|
+| **DCA / mean-reversion** | `MoutonMeanRevHyperOptLoss` | 8 métriques additives: CAGR (22%), K-ratio (22%), PF (12%), quarterly (14%), payoff (8%), diversité corr-daily (8%), TUW santé (8%), confiance sqrt (6%). Gates multiplicatives: concentration sigmoid + exp DD (×8). Hard filters avec gradient: profit, trades, WR≥55%, DD≤45%, pairs≥5 |
+| **Momentum / trend-following** | `MoutonMomentumHyperOptLoss` | 9 métriques additives: Sharpe (18%), payoff (18%), tail (14%), CAGR (13%), PF (9%), quarterly (9%), diversité corr-daily (7%), TUW santé (7%), confiance sqrt (5%). Gates multiplicatives: consec losses sigmoid + exp DD (×10). Hard filters avec gradient: profit, trades, DD≤40%, payoff≥0.5, pairs≥5 |
+| Diversifié multi-pair | `Mouton2HyperOptLoss` | Analyse trimestrielle pondérée + multi-metric + per-pair scoring (75% global / 25% par paire) |
+
+### Loss functions standard freqtrade
+
 | Comportement stratégie | Use | Do NOT use |
 |---|---|---|
 | Patient (attend jours/semaines) | `CalmarHyperOptLoss` | `SharpeHyperOptLossDaily` (pénalise inactivité) |
 | Fréquente (trades chaque jour) | `SharpeHyperOptLossDaily` | `CalmarHyperOptLoss` (ignore consistance) |
 | Safety-first (DD = mort) | `MaxDrawDownHyperOptLoss` | Raw profit losses |
-| Diversifié multi-pair | `Mouton2HyperOptLoss` | Anything sans pair diversity penalty |
 
-**Calmar = profit / max drawdown.** Best pour DCA qui doit sit out les bear markets. Un bot qui ne trade pas pendant 2 semaines mais évite un crash -50% score mieux qu'un bot qui trade quotidiennement à travers le crash.
+### Pourquoi MoutonMeanRev et pas Calmar ?
 
-**Sharpe pénalise les jours à rendement zéro.** Pousse l'optimizer vers des params qui entrent chaque jour — exactement faux pour une stratégie mean-reversion qui doit attendre des setups extrêmes.
+**Calmar** = profit / max drawdown, point. `MoutonMeanRevHyperOptLoss` utilise 8 métriques additives à poids honnêtes (ce que le poids dit = ce que la métrique pèse réellement) + 2 gates multiplicatives intentionnellement dominantes (concentration, DD exp). Architecture:
+
+- **Additif (discrimine entre bonnes stratégies)**: CAGR 22%, K-ratio Kestner 22%, PF 12%, quarterly consistance+magnitude 14%, payoff 8%, diversité daily-corr 8%, TUW santé 8%, confiance sqrt 6%
+- **Gates (élimine les mauvaises)**: concentration sigmoid centrée 0.4, exp(8×DD)
+- **Hard filters avec gradient TPE**: WR≥55% (DCA doit reverter), DD≤45%, trades≥60, pairs≥5
+
+Pas d'expectancy (redondant avec PF+payoff — 3 métriques pour la même info). Quarterly inclut maintenant la magnitude (pire trimestre vs moyenne), pas juste binaire profitable/pas. Diversité utilise des buckets journaliers pour la corrélation (le timestamp exact produisait une matrice creuse inutile).
+
+### Pourquoi MoutonMomentum et pas Sharpe ?
+
+**Sharpe** = return / volatilité, point. `MoutonMomentumHyperOptLoss` utilise 9 métriques additives + 2 gates multiplicatives. Architecture:
+
+- **Additif**: Sharpe 18%, payoff 18%, tail ratio 14%, CAGR 13%, PF 9%, quarterly+magnitude 9%, diversité daily-corr 7%, TUW santé 7%, confiance sqrt 5%
+- **Gates**: consec losses sigmoid centrée 12, exp(10×DD) — plus strict que MeanRev
+- **Hard filters avec gradient TPE**: payoff≥0.5 (let profits run obligatoire), DD≤40%, trades≥40, pairs≥5
+
+TUW et confiance sont additives (poids honnêtes), pas multiplicatives stackées. Seules les gates (consec losses, DD) sont multiplicatives — c'est voulu et documenté.
 
 ## Common traps (retour d'expérience)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ I've been running Freqtrade in production for **four years now**. Over that time
 - I can iterate freely on the parts that matter to my stack (Hyperliquid, DCA, fleet monitoring) without waiting for upstream review.
 - Anyone who finds one of these changes useful can **cherry-pick it into their own setup** — or use this whole fork as a drop-in replacement. Everything here is GPL-3.0, just like upstream.
 
-Upstream Freqtrade is already excellent as a general-purpose trading framework. This fork adds the handful of things I've needed while running several bots in production: automatic recovery when a position is closed externally (ADL, manual close on the exchange UI), first-class liquidation detection on Hyperliquid, a pairlist filter built for short-only strategies, a custom hyperopt loss, a more ergonomic hyperopt CLI, and a redirect so `freqtrade install-ui` pulls my companion FreqUI fork.
+Upstream Freqtrade is already excellent as a general-purpose trading framework. This fork adds the handful of things I've needed while running several bots in production: automatic recovery when a position is closed externally (ADL, manual close on the exchange UI), first-class liquidation detection on Hyperliquid, a pairlist filter built for short-only strategies, custom hyperopt losses (one for DCA/mean-reversion, one for momentum/trend-following), a more ergonomic hyperopt CLI, and a redirect so `freqtrade install-ui` pulls my companion FreqUI fork.
 
 <p align="center">
   <img src=".readme_illustrations/frequi-dashboard-overview.png" alt="FreqUI fork dashboard — pulled automatically by 'freqtrade install-ui' in this fork" width="900">
@@ -32,13 +32,13 @@ Five concrete motivations on top of the rationale above:
 
 1. **Hyperliquid-grade resiliency.** On DEXes (and sometimes on CEXes too) a position can disappear from under you — ADL, manual close from the web UI, liquidation. Vanilla Freqtrade loses sync in those cases and keeps looping. This fork detects all three cases and closes the trade cleanly in the DB.
 2. **A complete FreqUI overhaul.** The stock FreqUI is functional but minimal. I wanted fleet-level monitoring, rich popovers with market context (BTC/ETH benchmarks, Fear & Greed index), per-bot alerts, drag-and-drop dashboard layout, and full i18n. So I built [titouannwtt/frequi-fork](https://github.com/titouannwtt/frequi-fork) — a near-complete rewrite of the UI. In this fork, `freqtrade install-ui` pulls it automatically, no extra setup needed.
-3. **Short-DCA friendly tools.** A pairlist filter that excludes pairs with a strong linear uptrend (high R² on price regression), a custom hyperopt loss tuned for DCA strategies, and a hyperopt CLI that lets you swap Optuna samplers without touching your strategy file.
+3. **Short-DCA friendly tools.** A pairlist filter that excludes pairs with a strong linear uptrend (high R² on price regression), custom hyperopt losses tuned for DCA and momentum strategies, and a hyperopt CLI that lets you swap Optuna samplers without touching your strategy file.
 4. **A more powerful hyperopt CLI.** Vanilla Freqtrade hardcodes the Optuna sampler. This fork adds a `--sampler` flag that lets you pick from six samplers (TPE, NSGA-II, NSGA-III, CMA-ES, GP, QMC) without editing your strategy — useful for A/B testing convergence approaches across different loss functions.
 5. **Sensible defaults for a full stack.** Launch scripts with auto-restart, a download script for recent data, ready-to-use backtest configs for 6 exchanges, and live config templates with API key placeholders.
 
 ### What's added on top of upstream freqtrade/stable
 
-Concrete list of fork-only changes (17 code files, +600 / -8 lines vs. `upstream/stable`, plus documentation and config templates):
+Concrete list of fork-only changes (19 code files, +1280 / -8 lines vs. `upstream/stable`, plus documentation and config templates):
 
 #### Trading engine
 
@@ -65,6 +65,8 @@ Concrete list of fork-only changes (17 code files, +600 / -8 lines vs. `upstream
 | File | Added | Purpose |
 |------|-------|---------|
 | `freqtrade/optimize/hyperopt_loss/hyperopt_loss_my_profit_drawdown.py` | +54 lines | **New hyperopt loss** — profit × drawdown-penalty with a configurable `DRAWDOWN_MULT`. Used as a baseline when tuning DCA strategies. |
+| `freqtrade/optimize/hyperopt_loss/hyperopt_loss_mouton_meanrev.py` | +338 lines | **New hyperopt loss for DCA / mean-reversion** — 8 additive metrics (CAGR 22%, K-ratio 22%, PF 12%, quarterly consistency 14%, payoff 8%, pair diversity 8%, TUW health 8%, confidence 6%) + 2 multiplicative gates (concentration sigmoid, exp drawdown). Hard filters with TPE gradient: WR ≥ 55%, DD ≤ 45%, trades ≥ 60, pairs ≥ 5. Doesn't penalize inactivity, uses daily-bucketed correlation for diversity. |
+| `freqtrade/optimize/hyperopt_loss/hyperopt_loss_mouton_momentum.py` | +340 lines | **New hyperopt loss for momentum / trend-following** — 9 additive metrics (Sharpe 18%, payoff 18%, tail ratio 14%, CAGR 13%, PF 9%, quarterly 9%, diversity 7%, TUW 7%, confidence 5%) + 2 multiplicative gates (consecutive losses sigmoid, exp drawdown). Hard filters: DD ≤ 40%, payoff ≥ 0.5, trades ≥ 40, pairs ≥ 5. Rewards right-skew and "let profits run". |
 | `freqtrade/commands/cli_options.py` | +21 lines | **New `--sampler` CLI option** for `freqtrade hyperopt`. Choices: `NSGAIIISampler` (default, genetic multi-objective — good Pareto diversity), `NSGAIISampler` (older variant), `TPESampler` (Bayesian, fast convergence on single-objective losses), `CmaEsSampler` (gradient-free for continuous spaces), `GPSampler` (Gaussian-Process Bayesian), `QMCSampler` (Quasi-Monte Carlo — pure exploration). Overrides whatever `HyperOpt.generate_estimator()` returns, so you can A/B samplers without editing the strategy. |
 | `freqtrade/commands/arguments.py` | +1 line | Wires `--sampler` into `ARGS_HYPEROPT`. |
 | `freqtrade/configuration/configuration.py` | +1 line | Logs the selected sampler when `--sampler` is used. |
@@ -233,13 +235,13 @@ Au-delà de ça, cinq motivations concrètes :
 
 1. **Résilience type Hyperliquid.** Sur les DEX (et parfois sur CEX aussi), une position peut disparaître sous tes pieds — ADL, fermeture manuelle depuis l'UI de l'exchange, liquidation. Freqtrade vanilla perd la sync dans ces cas-là et boucle indéfiniment. Ce fork détecte les trois cas et ferme proprement le trade dans la DB.
 2. **Une refonte complète de FreqUI.** L'interface stock de FreqUI est fonctionnelle mais minimaliste. Je voulais du monitoring de flotte, des popovers riches avec contexte de marché (benchmarks BTC/ETH, indice Fear & Greed), des alertes par bot, un dashboard drag-and-drop, et une i18n complète. J'ai donc construit [titouannwtt/frequi-fork](https://github.com/titouannwtt/frequi-fork) — une réécriture quasi-totale de l'UI. Dans ce fork, `freqtrade install-ui` la récupère automatiquement, aucun setup supplémentaire.
-3. **Outils pensés pour le DCA short.** Un filtre de pairlist qui exclut les paires en tendance haussière régulière (R² élevé sur régression linéaire du prix), une loss hyperopt custom calibrée pour les stratégies DCA, et une CLI hyperopt qui permet de changer de sampler Optuna sans toucher au fichier de stratégie.
+3. **Outils pensés pour le DCA short.** Un filtre de pairlist qui exclut les paires en tendance haussière régulière (R² élevé sur régression linéaire du prix), des losses hyperopt custom calibrées pour les stratégies DCA et momentum, et une CLI hyperopt qui permet de changer de sampler Optuna sans toucher au fichier de stratégie.
 4. **Un CLI hyperopt plus puissant.** Freqtrade vanilla hardcode le sampler Optuna. Ce fork ajoute un flag `--sampler` qui permet de choisir parmi six samplers (TPE, NSGA-II, NSGA-III, CMA-ES, GP, QMC) sans éditer la stratégie — utile pour A/B tester les approches de convergence selon la loss function utilisée.
 5. **Stack complet utilisable d'emblée.** Scripts de lancement avec auto-restart, script de téléchargement des données récentes, configs de backtest prêtes à l'emploi pour 6 exchanges, et templates de configs live avec placeholders pour les clés API.
 
 ### Ce que ce fork apporte vs. upstream freqtrade/stable
 
-Liste concrète des changements (17 fichiers de code, +600 / -8 lignes vs. `upstream/stable`, plus documentation et templates de config) :
+Liste concrète des changements (19 fichiers de code, +1280 / -8 lignes vs. `upstream/stable`, plus documentation et templates de config) :
 
 #### Moteur de trading
 
@@ -266,6 +268,8 @@ Liste concrète des changements (17 fichiers de code, +600 / -8 lignes vs. `upst
 | Fichier | Ajouté | Rôle |
 |---------|--------|------|
 | `freqtrade/optimize/hyperopt_loss/hyperopt_loss_my_profit_drawdown.py` | +54 lignes | **Nouvelle loss hyperopt** — profit × pénalité drawdown avec `DRAWDOWN_MULT` configurable. Utilisée comme baseline pour tuner les stratégies DCA. |
+| `freqtrade/optimize/hyperopt_loss/hyperopt_loss_mouton_meanrev.py` | +338 lignes | **Nouvelle loss pour DCA / mean-reversion** — 8 métriques additives (CAGR 22%, K-ratio 22%, PF 12%, quarterly 14%, payoff 8%, diversité pairs 8%, TUW santé 8%, confiance 6%) + 2 gates multiplicatives (concentration sigmoid, exp DD). Hard filters avec gradient TPE : WR ≥ 55%, DD ≤ 45%, trades ≥ 60, pairs ≥ 5. Ne pénalise pas l'inactivité, corrélation par buckets journaliers. |
+| `freqtrade/optimize/hyperopt_loss/hyperopt_loss_mouton_momentum.py` | +340 lignes | **Nouvelle loss pour momentum / trend-following** — 9 métriques additives (Sharpe 18%, payoff 18%, tail ratio 14%, CAGR 13%, PF 9%, quarterly 9%, diversité 7%, TUW 7%, confiance 5%) + 2 gates multiplicatives (consec losses sigmoid, exp DD). Hard filters : DD ≤ 40%, payoff ≥ 0.5, trades ≥ 40, pairs ≥ 5. Récompense le skew droit et le "let profits run". |
 | `freqtrade/commands/cli_options.py` | +21 lignes | **Nouvelle option `--sampler`** pour `freqtrade hyperopt`. Choix : `NSGAIIISampler` (défaut, génétique multi-objectif — bonne diversité Pareto), `NSGAIISampler` (variante plus ancienne), `TPESampler` (bayésien, convergence rapide sur losses mono-objectif), `CmaEsSampler` (sans gradient, pour espaces continus), `GPSampler` (bayésien à processus gaussien), `QMCSampler` (Quasi-Monte Carlo — exploration pure). Écrase ce que retourne `HyperOpt.generate_estimator()`, donc tu peux A/B tester les samplers sans éditer la stratégie. |
 | `freqtrade/commands/arguments.py` | +1 ligne | Branche `--sampler` dans `ARGS_HYPEROPT`. |
 | `freqtrade/configuration/configuration.py` | +1 ligne | Log du sampler choisi quand `--sampler` est utilisé. |

--- a/freqtrade/optimize/hyperopt_loss/hyperopt_loss_mouton_meanrev.py
+++ b/freqtrade/optimize/hyperopt_loss/hyperopt_loss_mouton_meanrev.py
@@ -1,0 +1,338 @@
+"""
+MoutonMeanRevHyperOptLoss — Hyperopt loss for DCA / mean-reversion strategies.
+
+Design principles (from tips.txt):
+  - NOT Sharpe: inactivity is discipline, not dysfunction (#2, #70)
+  - High win-rate alone is meaningless — check payoff ratio (#4, #188)
+  - Frequent small profits > rare big ones — reward consistency (#6)
+  - Concentrated profit = red flag — smooth sigmoid gate (#161)
+  - No cherry-picking pairs — require diversity with daily correlation adj (#106)
+  - Quarterly consistency: binary profitable + magnitude regularity
+  - Max drawdown hard cap + exponential gate — catastrophe protection (#40, #67)
+  - K-ratio of equity curve — slope/SE(slope), discriminates better than R²
+  - DCA win rate floor — WR < 55% is pathological for mean-reversion
+
+Additive metrics (weighted, sum = 1.0 — weights reflect actual influence):
+  Annualized return ......... 0.22  (profit/time without DD)
+  K-ratio equity curve ...... 0.22  (slope / SE — smooth growth)
+  Profit factor ............. 0.12  (gross wins / gross losses)
+  Payoff ratio .............. 0.08  (avg_win / avg_loss — asymmetry check)
+  Quarterly consistency ..... 0.14  (profitable quarters + magnitude regularity)
+  Pair diversity ............ 0.08  (daily-bucketed correlation-adjusted spread)
+  TUW health ................ 0.08  (time underwater score)
+  Confidence ................ 0.06  (sqrt-based sample size factor)
+
+Multiplicative gates (intentionally dominant — documented as such):
+  Concentration penalty ..... smooth sigmoid on top-2-trade profit share (#161)
+  Drawdown penalty .......... exponential: score / exp(8 * max_dd)
+
+Hard filters (return REJECT with gradient for TPE navigation):
+  - Total profit <= 0           (gradient: proportional to loss magnitude)
+  - Trade count < MIN_TRADES    (gradient: proportional to shortfall)
+  - Win rate < MIN_WIN_RATE     (gradient: proportional to shortfall)
+  - Max drawdown > MAX_DD       (gradient: proportional to excess DD)
+  - Pairs < MIN_PAIRS           (gradient: proportional to shortfall)
+  - Training period < 30 days
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from pandas import DataFrame
+
+from freqtrade.constants import Config
+from freqtrade.data.metrics import calculate_max_drawdown
+from freqtrade.optimize.hyperopt import IHyperOptLoss
+
+
+# ---------------------------------------------------------------------------
+# Tunable constants
+# ---------------------------------------------------------------------------
+MIN_TRADES = 60
+MIN_PAIRS = 5
+MIN_WIN_RATE = 0.55
+MAX_DD_ALLOWED = 0.45
+QUARTERLY_DECAY = 0.85
+
+W_RETURN = 0.22
+W_K_RATIO = 0.22
+W_PF = 0.12
+W_PAYOFF = 0.08
+W_QUARTERLY = 0.14
+W_DIVERSITY = 0.08
+W_TUW = 0.08
+W_CONFIDENCE = 0.06
+
+REJECT = 1e6
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _annualized_return(total_profit: float, starting_balance: float, days: int) -> float:
+    if days < 30 or total_profit <= 0 or starting_balance <= 0:
+        return 0.0
+    total_return = total_profit / starting_balance
+    return (1.0 + total_return) ** (365.0 / days) - 1.0
+
+
+def _k_ratio(arr: np.ndarray) -> float:
+    """Kestner K-ratio: slope / SE(slope)."""
+    n = len(arr)
+    if n < 3:
+        return 0.0
+    x = np.arange(n, dtype=float)
+    slope, intercept = np.polyfit(x, arr, 1)
+    if slope <= 0:
+        return 0.0
+    residuals = arr - (slope * x + intercept)
+    ss_res = np.sum(residuals ** 2)
+    se_slope = np.sqrt(ss_res / (n - 2)) / np.sqrt(np.sum((x - x.mean()) ** 2))
+    if se_slope < 1e-10:
+        return 20.0
+    return slope / se_slope
+
+
+def _profit_factor(results: DataFrame) -> float:
+    wins = results.loc[results["profit_abs"] > 0, "profit_abs"].sum()
+    losses = abs(results.loc[results["profit_abs"] < 0, "profit_abs"].sum())
+    if losses < 1e-8:
+        return min(wins, 20.0)
+    return wins / losses
+
+
+def _payoff_ratio(results: DataFrame) -> float:
+    wins = results.loc[results["profit_abs"] > 0, "profit_abs"]
+    losers = results.loc[results["profit_abs"] < 0, "profit_abs"]
+    avg_win = wins.mean() if len(wins) else 0.0
+    avg_loss = abs(losers.mean()) if len(losers) else 1e-8
+    if avg_loss < 1e-8:
+        return min(avg_win, 20.0)
+    return avg_win / avg_loss
+
+
+def _concentration_penalty(results: DataFrame) -> float:
+    """Smooth sigmoid gate: top-2 trades carrying >40% profit → score crushed."""
+    total = results["profit_abs"].sum()
+    if total <= 0:
+        return 0.0
+    top2_ratio = results["profit_abs"].nlargest(2).sum() / total
+    return float(np.clip(1.0 / (1.0 + np.exp(15.0 * (top2_ratio - 0.45))), 0.05, 1.0))
+
+
+def _max_time_underwater(results: DataFrame, starting_balance: float) -> float:
+    sorted_results = results.sort_values("close_date")
+    equity = starting_balance + sorted_results["profit_abs"].cumsum()
+    dates = pd.to_datetime(sorted_results["close_date"], utc=True)
+
+    peak = equity.cummax()
+    underwater = equity < peak
+
+    if not underwater.any():
+        return 0.0
+
+    groups = (~underwater).cumsum()
+    max_days = 0.0
+    for _, group_dates in dates[underwater].groupby(groups[underwater]):
+        if len(group_dates) >= 2:
+            duration = (group_dates.iloc[-1] - group_dates.iloc[0]).total_seconds() / 86400
+            max_days = max(max_days, duration)
+
+    return max_days
+
+
+def _quarterly_consistency(results: DataFrame, max_date: datetime) -> float:
+    """60% weighted binary (profitable or not) + 40% magnitude regularity."""
+    dates = pd.to_datetime(results["close_date"], utc=True)
+    results = results.copy()
+    results["_q"] = dates.dt.to_period("Q")
+    now_q = pd.Timestamp(max_date, tz="UTC").to_period("Q")
+
+    quarters = results.groupby("_q")["profit_abs"].sum()
+    if len(quarters) < 2:
+        return 0.5
+
+    weighted_profitable = 0.0
+    total_weight = 0.0
+    for q, profit in quarters.items():
+        dist = (now_q.year - q.year) * 4 + (now_q.quarter - q.quarter)
+        w = QUARTERLY_DECAY ** max(0, dist)
+        total_weight += w
+        if profit > 0:
+            weighted_profitable += w
+    pct_profitable = weighted_profitable / total_weight if total_weight > 0 else 0.0
+
+    avg_q = quarters.mean()
+    worst_q = quarters.min()
+    regularity = float(np.clip(1.0 + worst_q / abs(avg_q), 0.0, 1.0)) if avg_q > 0 else 0.0
+
+    return 0.6 * pct_profitable + 0.4 * regularity
+
+
+def _pair_diversity_score(results: DataFrame) -> float:
+    """Profit spread across pairs, discounted by daily-bucketed correlation."""
+    if "pair" not in results.columns:
+        return 0.5
+
+    pair_profits = results.groupby("pair")["profit_abs"].sum()
+    n_pairs = len(pair_profits)
+    if n_pairs < MIN_PAIRS:
+        return 0.0
+
+    profitable = (pair_profits > 0).sum()
+    frac_profitable = profitable / n_pairs
+
+    total = pair_profits.sum()
+    if total <= 0:
+        return 0.0
+
+    diversity = 1.0 - pair_profits.max() / total
+
+    corr_discount = 1.0
+    try:
+        daily = results.assign(
+            _day=pd.to_datetime(results["close_date"], utc=True).dt.date
+        )
+        pivot = daily.pivot_table(
+            values="profit_abs", index="_day", columns="pair", aggfunc="sum"
+        ).fillna(0)
+        if pivot.shape[1] >= 2 and pivot.shape[0] >= 10:
+            corr_matrix = pivot.corr()
+            n = len(corr_matrix)
+            avg_corr = (corr_matrix.values.sum() - n) / (n * n - n)
+            corr_discount = 1.0 - max(0.0, avg_corr) * 0.5
+    except (ValueError, KeyError):
+        pass
+
+    base = frac_profitable * 0.5 + diversity * 0.5
+    return float(np.clip(base * corr_discount, 0.0, 1.0))
+
+
+# ---------------------------------------------------------------------------
+# Normalisers
+# ---------------------------------------------------------------------------
+
+def _norm_return(v: float) -> float:
+    if v <= 0:
+        return 0.0
+    return float(np.clip(np.log1p(v) / np.log1p(1.5), 0.0, 1.0))
+
+
+def _norm_k_ratio(v: float) -> float:
+    if v <= 0:
+        return 0.0
+    return float(np.clip(v / 6.0, 0.0, 1.0))
+
+
+def _norm_pf(v: float) -> float:
+    if v <= 1.0:
+        return 0.0
+    return float(np.clip((v - 1.0) / 2.0, 0.0, 1.0))
+
+
+def _norm_payoff(v: float) -> float:
+    if v < 0.2:
+        return 0.0
+    return float(np.clip((v - 0.2) / 1.3, 0.0, 1.0))
+
+
+# ---------------------------------------------------------------------------
+# Main class
+# ---------------------------------------------------------------------------
+
+class MoutonMeanRevHyperOptLoss(IHyperOptLoss):
+    """
+    Hyperopt loss tailored for DCA / mean-reversion strategies.
+    8 additive metrics with honest weights + 2 multiplicative gates (concentration, DD).
+    """
+
+    @staticmethod
+    def hyperopt_loss_function(
+        *,
+        results: DataFrame,
+        trade_count: int,
+        min_date: datetime,
+        max_date: datetime,
+        config: Config,
+        processed: dict[str, DataFrame] | None = None,
+        backtest_stats: dict[str, Any] | None = None,
+        starting_balance: float = 1000,
+        **kwargs: Any,
+    ) -> float:
+
+        # --- Hard filters (with gradient for TPE) ---
+        if trade_count < MIN_TRADES:
+            return REJECT + (MIN_TRADES - trade_count) * 10
+
+        total_profit = results["profit_abs"].sum()
+        if total_profit <= 0:
+            return REJECT + abs(total_profit) * 10
+
+        days = (max_date - min_date).days
+        if days < 30:
+            return REJECT
+
+        wr = (results["profit_abs"] > 0).sum() / len(results)
+        if wr < MIN_WIN_RATE:
+            return REJECT + (MIN_WIN_RATE - wr) * 1000
+
+        try:
+            dd_result = calculate_max_drawdown(
+                results, value_col="profit_abs", starting_balance=starting_balance
+            )
+            max_dd = dd_result.relative_account_drawdown
+        except ValueError:
+            max_dd = 0.0
+
+        if max_dd > MAX_DD_ALLOWED:
+            return REJECT + max_dd * 100
+
+        n_pairs = results["pair"].nunique() if "pair" in results.columns else 0
+        if n_pairs < MIN_PAIRS:
+            return REJECT + (MIN_PAIRS - n_pairs) * 100
+
+        # --- Compute all 8 additive metrics ---
+        ann_return = _annualized_return(total_profit, starting_balance, days)
+
+        equity = (
+            starting_balance + results.sort_values("close_date")["profit_abs"].cumsum()
+        ).values
+        k_ratio = _k_ratio(equity)
+
+        pf = _profit_factor(results)
+        payoff = _payoff_ratio(results)
+        q_consistency = _quarterly_consistency(results, max_date)
+        diversity = _pair_diversity_score(results)
+
+        tuw = _max_time_underwater(results, starting_balance)
+        tuw_score = float(np.clip(1.0 - max(0.0, tuw - 45) / 135, 0.0, 1.0))
+
+        confidence = float(np.clip(
+            1.0 - 1.0 / np.sqrt(trade_count / MIN_TRADES), 0.0, 1.0
+        ))
+
+        # --- Weighted additive composite (honest weights) ---
+        composite = (
+            _norm_return(ann_return) * W_RETURN
+            + _norm_k_ratio(k_ratio) * W_K_RATIO
+            + _norm_pf(pf) * W_PF
+            + _norm_payoff(payoff) * W_PAYOFF
+            + q_consistency * W_QUARTERLY
+            + diversity * W_DIVERSITY
+            + tuw_score * W_TUW
+            + confidence * W_CONFIDENCE
+        )
+
+        # --- Multiplicative gates (intentionally dominant) ---
+        composite *= _concentration_penalty(results)
+        final = composite / np.exp(8.0 * max_dd)
+
+        if not np.isfinite(final):
+            return REJECT
+
+        return -float(final)

--- a/freqtrade/optimize/hyperopt_loss/hyperopt_loss_mouton_momentum.py
+++ b/freqtrade/optimize/hyperopt_loss/hyperopt_loss_mouton_momentum.py
@@ -1,0 +1,340 @@
+"""
+MoutonMomentumHyperOptLoss — Hyperopt loss for momentum / trend-following strategies.
+
+Design principles (from tips.txt):
+  - "Cut losses early, let profits run" — reward high payoff ratio (#124)
+  - Momentum works because of persistent behavioral bias (#75, #94)
+  - Risk management > buy/sell rules (#73, #55) — heavy drawdown penalty
+  - Sharpe IS appropriate here: momentum should trade regularly (#98)
+  - Asymmetric rules for asymmetric phenomena (#141) — reward right-tail skew
+  - Volatility targeting matters (#56) — penalize excessive volatility
+  - Need large universe for momentum (#104) — pair diversity required
+  - Low win-rate is OK if payoff compensates (#188) — don't over-weight WR
+  - Robustness > peak performance (#161) — quarterly stability matters
+  - Don't use Sortino (#98) — use Sharpe or Calmar
+
+Additive metrics (weighted, sum = 1.0 — weights reflect actual influence):
+  Sharpe ratio .............. 0.18  (risk-adjusted return, penalizes irregularity)
+  Payoff ratio .............. 0.18  (avg_win / avg_loss — "let profits run")
+  Tail ratio ................ 0.14  (right tail vs left tail — skew quality)
+  Annualized return ......... 0.13  (profit/time — no DD double-counting)
+  Profit factor ............. 0.09  (gross wins / gross losses)
+  Quarterly consistency ..... 0.09  (profitable quarters + magnitude regularity)
+  Pair diversity ............ 0.07  (daily-bucketed correlation-adjusted spread)
+  TUW health ................ 0.07  (time underwater score)
+  Confidence ................ 0.05  (sqrt-based sample size factor)
+
+Multiplicative gates (intentionally dominant — documented as such):
+  Consecutive loss penalty .. smooth sigmoid centered at 12
+  Drawdown penalty .......... exponential: score / exp(10 * max_dd)
+
+Hard filters (return REJECT with gradient for TPE navigation):
+  - Total profit <= 0           (gradient: proportional to loss magnitude)
+  - Trade count < MIN_TRADES    (gradient: proportional to shortfall)
+  - Max drawdown > MAX_DD       (gradient: proportional to excess DD)
+  - Payoff ratio < 0.5          (gradient: proportional to shortfall)
+  - Pairs < MIN_PAIRS           (gradient: proportional to shortfall)
+  - Training period < 30 days
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from pandas import DataFrame
+
+from freqtrade.constants import Config
+from freqtrade.data.metrics import calculate_max_drawdown, calculate_sharpe
+from freqtrade.optimize.hyperopt import IHyperOptLoss
+
+
+# ---------------------------------------------------------------------------
+# Tunable constants
+# ---------------------------------------------------------------------------
+MIN_TRADES = 40
+MIN_PAIRS = 5
+MAX_DD_ALLOWED = 0.40
+MIN_PAYOFF_RATIO = 0.5
+QUARTERLY_DECAY = 0.85
+
+W_SHARPE = 0.18
+W_PAYOFF = 0.18
+W_TAIL = 0.14
+W_RETURN = 0.13
+W_PF = 0.09
+W_QUARTERLY = 0.09
+W_DIVERSITY = 0.07
+W_TUW = 0.07
+W_CONFIDENCE = 0.05
+
+REJECT = 1e6
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _annualized_return(total_profit: float, starting_balance: float, days: int) -> float:
+    if days < 30 or total_profit <= 0 or starting_balance <= 0:
+        return 0.0
+    total_return = total_profit / starting_balance
+    return (1.0 + total_return) ** (365.0 / days) - 1.0
+
+
+def _payoff_ratio(results: DataFrame) -> float:
+    wins = results.loc[results["profit_abs"] > 0, "profit_abs"]
+    losers = results.loc[results["profit_abs"] < 0, "profit_abs"]
+    avg_win = wins.mean() if len(wins) else 0.0
+    avg_loss = abs(losers.mean()) if len(losers) else 1e-8
+    if avg_loss < 1e-8:
+        return min(avg_win, 20.0)
+    return avg_win / avg_loss
+
+
+def _profit_factor(results: DataFrame) -> float:
+    wins = results.loc[results["profit_abs"] > 0, "profit_abs"].sum()
+    losses = abs(results.loc[results["profit_abs"] < 0, "profit_abs"].sum())
+    if losses < 1e-8:
+        return min(wins, 20.0)
+    return wins / losses
+
+
+def _tail_ratio(results: DataFrame) -> float:
+    """p95 / |p5| — momentum MUST have fatter right tail than left."""
+    profits = results["profit_abs"]
+    if len(profits) < 20:
+        return 1.0
+    p95 = np.percentile(profits, 95)
+    p5 = np.percentile(profits, 5)
+    if abs(p5) < 1e-8:
+        return min(abs(p95), 10.0) if p95 > 0 else 0.0
+    return abs(p95 / p5)
+
+
+def _consecutive_losses(results: DataFrame) -> int:
+    is_loss = (results.sort_values("close_date")["profit_abs"] < 0).astype(int)
+    if len(is_loss) == 0:
+        return 0
+    groups = (is_loss != is_loss.shift()).cumsum()
+    streaks = is_loss.groupby(groups).sum()
+    return int(streaks.max()) if len(streaks) > 0 else 0
+
+
+def _max_time_underwater(results: DataFrame, starting_balance: float) -> float:
+    sorted_results = results.sort_values("close_date")
+    equity = starting_balance + sorted_results["profit_abs"].cumsum()
+    dates = pd.to_datetime(sorted_results["close_date"], utc=True)
+
+    peak = equity.cummax()
+    underwater = equity < peak
+
+    if not underwater.any():
+        return 0.0
+
+    groups = (~underwater).cumsum()
+    max_days = 0.0
+    for _, group_dates in dates[underwater].groupby(groups[underwater]):
+        if len(group_dates) >= 2:
+            duration = (group_dates.iloc[-1] - group_dates.iloc[0]).total_seconds() / 86400
+            max_days = max(max_days, duration)
+
+    return max_days
+
+
+def _quarterly_consistency(results: DataFrame, max_date: datetime) -> float:
+    """60% weighted binary (profitable or not) + 40% magnitude regularity."""
+    dates = pd.to_datetime(results["close_date"], utc=True)
+    results = results.copy()
+    results["_q"] = dates.dt.to_period("Q")
+    now_q = pd.Timestamp(max_date, tz="UTC").to_period("Q")
+
+    quarters = results.groupby("_q")["profit_abs"].sum()
+    if len(quarters) < 2:
+        return 0.5
+
+    weighted_profitable = 0.0
+    total_weight = 0.0
+    for q, profit in quarters.items():
+        dist = (now_q.year - q.year) * 4 + (now_q.quarter - q.quarter)
+        w = QUARTERLY_DECAY ** max(0, dist)
+        total_weight += w
+        if profit > 0:
+            weighted_profitable += w
+    pct_profitable = weighted_profitable / total_weight if total_weight > 0 else 0.0
+
+    avg_q = quarters.mean()
+    worst_q = quarters.min()
+    regularity = float(np.clip(1.0 + worst_q / abs(avg_q), 0.0, 1.0)) if avg_q > 0 else 0.0
+
+    return 0.6 * pct_profitable + 0.4 * regularity
+
+
+def _pair_diversity_score(results: DataFrame) -> float:
+    """Profit spread across pairs, discounted by daily-bucketed correlation."""
+    if "pair" not in results.columns:
+        return 0.5
+
+    pair_profits = results.groupby("pair")["profit_abs"].sum()
+    n_pairs = len(pair_profits)
+    if n_pairs < MIN_PAIRS:
+        return 0.0
+
+    profitable = (pair_profits > 0).sum()
+    frac_profitable = profitable / n_pairs
+
+    total = pair_profits.sum()
+    if total <= 0:
+        return 0.0
+
+    diversity = 1.0 - pair_profits.max() / total
+
+    corr_discount = 1.0
+    try:
+        daily = results.assign(
+            _day=pd.to_datetime(results["close_date"], utc=True).dt.date
+        )
+        pivot = daily.pivot_table(
+            values="profit_abs", index="_day", columns="pair", aggfunc="sum"
+        ).fillna(0)
+        if pivot.shape[1] >= 2 and pivot.shape[0] >= 10:
+            corr_matrix = pivot.corr()
+            n = len(corr_matrix)
+            avg_corr = (corr_matrix.values.sum() - n) / (n * n - n)
+            corr_discount = 1.0 - max(0.0, avg_corr) * 0.5
+    except (ValueError, KeyError):
+        pass
+
+    base = frac_profitable * 0.5 + diversity * 0.5
+    return float(np.clip(base * corr_discount, 0.0, 1.0))
+
+
+# ---------------------------------------------------------------------------
+# Normalisers
+# ---------------------------------------------------------------------------
+
+def _norm_sharpe(v: float) -> float:
+    if v <= 0:
+        return 0.0
+    return float(np.clip(v / 3.0, 0.0, 1.0))
+
+
+def _norm_payoff(v: float) -> float:
+    if v < 0.5:
+        return 0.0
+    return float(np.clip((v - 0.5) / 2.0, 0.0, 1.0))
+
+
+def _norm_tail(v: float) -> float:
+    if v <= 0.8:
+        return 0.0
+    return float(np.clip((v - 0.8) / 2.5, 0.0, 1.0))
+
+
+def _norm_return(v: float) -> float:
+    if v <= 0:
+        return 0.0
+    return float(np.clip(np.log1p(v) / np.log1p(2.0), 0.0, 1.0))
+
+
+def _norm_pf(v: float) -> float:
+    if v <= 1.0:
+        return 0.0
+    return float(np.clip((v - 1.0) / 2.0, 0.0, 1.0))
+
+
+# ---------------------------------------------------------------------------
+# Main class
+# ---------------------------------------------------------------------------
+
+class MoutonMomentumHyperOptLoss(IHyperOptLoss):
+    """
+    Hyperopt loss tailored for momentum / trend-following strategies.
+    9 additive metrics with honest weights + 2 multiplicative gates (consec losses, DD).
+    """
+
+    @staticmethod
+    def hyperopt_loss_function(
+        *,
+        results: DataFrame,
+        trade_count: int,
+        min_date: datetime,
+        max_date: datetime,
+        config: Config,
+        processed: dict[str, DataFrame] | None = None,
+        backtest_stats: dict[str, Any] | None = None,
+        starting_balance: float = 1000,
+        **kwargs: Any,
+    ) -> float:
+
+        # --- Hard filters (with gradient for TPE) ---
+        if trade_count < MIN_TRADES:
+            return REJECT + (MIN_TRADES - trade_count) * 10
+
+        total_profit = results["profit_abs"].sum()
+        if total_profit <= 0:
+            return REJECT + abs(total_profit) * 10
+
+        days = (max_date - min_date).days
+        if days < 30:
+            return REJECT
+
+        try:
+            dd_result = calculate_max_drawdown(
+                results, value_col="profit_abs", starting_balance=starting_balance
+            )
+            max_dd = dd_result.relative_account_drawdown
+        except ValueError:
+            max_dd = 0.0
+
+        if max_dd > MAX_DD_ALLOWED:
+            return REJECT + max_dd * 100
+
+        payoff = _payoff_ratio(results)
+        if payoff < MIN_PAYOFF_RATIO:
+            return REJECT + (MIN_PAYOFF_RATIO - payoff) * 1000
+
+        n_pairs = results["pair"].nunique() if "pair" in results.columns else 0
+        if n_pairs < MIN_PAIRS:
+            return REJECT + (MIN_PAIRS - n_pairs) * 100
+
+        # --- Compute all 9 additive metrics ---
+        sharpe = calculate_sharpe(results, min_date, max_date, starting_balance)
+        tail = _tail_ratio(results)
+        ann_return = _annualized_return(total_profit, starting_balance, days)
+        pf = _profit_factor(results)
+        q_consistency = _quarterly_consistency(results, max_date)
+        diversity = _pair_diversity_score(results)
+
+        tuw = _max_time_underwater(results, starting_balance)
+        tuw_score = float(np.clip(1.0 - max(0.0, tuw - 30) / 120, 0.0, 1.0))
+
+        confidence = float(np.clip(
+            1.0 - 1.0 / np.sqrt(trade_count / MIN_TRADES), 0.0, 1.0
+        ))
+
+        # --- Weighted additive composite (honest weights) ---
+        composite = (
+            _norm_sharpe(sharpe) * W_SHARPE
+            + _norm_payoff(payoff) * W_PAYOFF
+            + _norm_tail(tail) * W_TAIL
+            + _norm_return(ann_return) * W_RETURN
+            + _norm_pf(pf) * W_PF
+            + q_consistency * W_QUARTERLY
+            + diversity * W_DIVERSITY
+            + tuw_score * W_TUW
+            + confidence * W_CONFIDENCE
+        )
+
+        # --- Multiplicative gates (intentionally dominant) ---
+        max_consec = _consecutive_losses(results)
+        consec_penalty = 0.3 + 0.7 / (1.0 + np.exp(0.4 * (max_consec - 12)))
+        composite *= consec_penalty
+        final = composite / np.exp(10.0 * max_dd)
+
+        if not np.isfinite(final):
+            return REJECT
+
+        return -float(final)


### PR DESCRIPTION
## Summary

Two custom multi-metric hyperopt loss functions, each tailored to a strategy family — replacing the need to rely on single-metric losses (Calmar, Sharpe) that either penalize healthy behavior or miss critical dimensions.

### MoutonMeanRevHyperOptLoss (DCA / mean-reversion)

**Problem with Calmar:** triple-counts drawdown (ratio + penalty + filter), and is a single ratio that can't distinguish between "good for different reasons" strategies.

**Architecture:** 8 additive metrics with honest weights (sum = 1.0) + 2 multiplicative gates.

| Metric | Weight | Why |
|--------|--------|-----|
| CAGR (annualized return) | 22% | Profit/time without DD double-counting |
| K-ratio (Kestner) | 22% | slope/SE(slope) — doesn't saturate on cumulative sums like R² |
| Profit factor | 12% | Gross wins / gross losses |
| Quarterly consistency | 14% | 60% binary profitable + 40% worst_q/avg_q regularity |
| Payoff ratio | 8% | avg_win / avg_loss |
| Pair diversity | 8% | Daily-bucketed correlation-adjusted profit spread |
| TUW health | 8% | Time underwater scoring |
| Confidence | 6% | sqrt-based sample size factor |

**Gates:** concentration sigmoid (center 0.45) + exp(8 × max_dd)
**Hard filters:** profit > 0, trades ≥ 60, WR ≥ 55%, DD ≤ 45%, pairs ≥ 5, days ≥ 30

### MoutonMomentumHyperOptLoss (trend-following)

**Problem with Sharpe:** return/volatility is a single dimension — misses tail quality, payoff asymmetry, and consecutive loss patterns that matter for momentum.

**Architecture:** 9 additive metrics with honest weights + 2 multiplicative gates.

| Metric | Weight | Why |
|--------|--------|-----|
| Sharpe ratio | 18% | Risk-adjusted return (appropriate here — momentum trades regularly) |
| Payoff ratio | 18% | "Let profits run" is mandatory for momentum |
| Tail ratio (p95/\|p5\|) | 14% | Right-skew quality — momentum must have fat right tail |
| CAGR | 13% | Profit/time |
| Profit factor | 9% | Gross wins / gross losses |
| Quarterly consistency | 9% | Same dual metric as MeanRev |
| Pair diversity | 7% | Same daily-bucketed correlation |
| TUW health | 7% | Time underwater |
| Confidence | 5% | Sample size |

**Gates:** consecutive losses sigmoid (center 12) + exp(10 × max_dd) — stricter than MeanRev
**Hard filters:** profit > 0, trades ≥ 40, DD ≤ 40%, payoff ≥ 0.5, pairs ≥ 5, days ≥ 30

### Key design decisions

- **Additive metrics + multiplicative gates** — metrics discriminate between good strategies, gates eliminate bad ones. Documented and intentional.
- **TPE gradient signals** on hard filters (`REJECT + shortfall × coeff`) — guides the optimizer away from rejected regions instead of creating a flat rejection plateau.
- **Daily-bucketed correlation** for pair diversity — timestamp-level pivot produces sparse matrices that make correlation useless.
- **K-ratio (Kestner)** instead of R² — R² saturates near 1.0 on any cumulative sum with enough trades; K-ratio (slope/SE) keeps discriminating.
- **No win-rate filter on Momentum** — low WR is fine if payoff compensates (trend-following characteristic).
- **WR ≥ 55% on MeanRev** — DCA that doesn't revert > half the time is pathological.

### Documentation

- `.claude-tips/hyperopt.md` updated with loss function comparison table, architecture breakdowns for both losses, and guidance on when to use each.
- `README.md` updated in both EN and FR sections with new Hyperopt table rows and line counts.

## Commits

1. `feat: add MoutonMeanRevHyperOptLoss` — the DCA/mean-reversion loss (+338 lines)
2. `feat: add MoutonMomentumHyperOptLoss` — the momentum/trend-following loss (+340 lines)
3. `docs: document custom loss functions in hyperopt tips` — hyperopt.md reference
4. `docs: update README with new hyperopt loss functions` — EN + FR sections

## Test plan

- [ ] `ruff check freqtrade/optimize/hyperopt_loss/hyperopt_loss_mouton_meanrev.py`
- [ ] `ruff check freqtrade/optimize/hyperopt_loss/hyperopt_loss_mouton_momentum.py`
- [ ] Run a short hyperopt (50 epochs) with `--hyperopt-loss MoutonMeanRevHyperOptLoss` on a DCA strategy
- [ ] Run a short hyperopt (50 epochs) with `--hyperopt-loss MoutonMomentumHyperOptLoss` on a momentum strategy
- [ ] Verify both losses reject unprofitable epochs (check `.fthypt` for REJECT values)
- [ ] Verify gradient signals work (rejected epochs should have different loss values, not all identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)