### PR TITLE
fix: handle tz-aware max_date in quarterly consistency

### DIFF
--- a/freqtrade/optimize/hyperopt_loss/hyperopt_loss_mouton_meanrev.py
+++ b/freqtrade/optimize/hyperopt_loss/hyperopt_loss_mouton_meanrev.py
@@ -151,7 +151,10 @@ def _quarterly_consistency(results: DataFrame, max_date: datetime) -> float:
     dates = pd.to_datetime(results["close_date"], utc=True)
     results = results.copy()
     results["_q"] = dates.dt.to_period("Q")
-    now_q = pd.Timestamp(max_date, tz="UTC").to_period("Q")
+    ts = pd.Timestamp(max_date)
+    if ts.tzinfo is None:
+        ts = ts.tz_localize("UTC")
+    now_q = ts.to_period("Q")
 
     quarters = results.groupby("_q")["profit_abs"].sum()
     if len(quarters) < 2:

--- a/freqtrade/optimize/hyperopt_loss/hyperopt_loss_mouton_momentum.py
+++ b/freqtrade/optimize/hyperopt_loss/hyperopt_loss_mouton_momentum.py
@@ -149,7 +149,10 @@ def _quarterly_consistency(results: DataFrame, max_date: datetime) -> float:
     dates = pd.to_datetime(results["close_date"], utc=True)
     results = results.copy()
     results["_q"] = dates.dt.to_period("Q")
-    now_q = pd.Timestamp(max_date, tz="UTC").to_period("Q")
+    ts = pd.Timestamp(max_date)
+    if ts.tzinfo is None:
+        ts = ts.tz_localize("UTC")
+    now_q = ts.to_period("Q")
 
     quarters = results.groupby("_q")["profit_abs"].sum()
     if len(quarters) < 2:


### PR DESCRIPTION
pd.Timestamp(max_date, tz="UTC") raises TypeError when max_date is already timezone-aware (e.g. from freqtrade's backtest engine which passes tz-aware datetimes). Fix: construct Timestamp first, then tz_localize only if naive.

Affects both MoutonMeanRev and MoutonMomentum _quarterly_consistency().

<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

Solve the issue: #___

## Quick changelog

- <change log 1>
- <change log 1>

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
