### PR TITLE
Merge upstream freqtrade 2026.5.1

### DIFF
--- a/freqtrade/__init__.py
+++ b/freqtrade/__init__.py
@@ -1,6 +1,6 @@
 """Freqtrade bot"""
 
-__version__ = "2026.5"
+__version__ = "2026.5.1"
 
 if "dev" in __version__:
     from pathlib import Path

--- a/ft_client/freqtrade_client/__init__.py
+++ b/ft_client/freqtrade_client/__init__.py
@@ -1,7 +1,7 @@
 from freqtrade_client.ft_rest_client import FtRestClient
 
 
-__version__ = "2026.5"
+__version__ = "2026.5.1"
 
 if "dev" in __version__:
     from pathlib import Path


### PR DESCRIPTION
## Upstream release: [freqtrade 2026.5.1](https://github.com/freqtrade/freqtrade/releases/tag/2026.5.1) (2026-06-03)

Patch release shipping a freqUI chart-rendering bugfix (bundled UI artifact rebuilt from the FreqUI 3.0.2 release).

## Diff applied

```
freqtrade/__init__.py                  | 2 +-
ft_client/freqtrade_client/__init__.py | 2 +-
2 files changed, 2 insertions(+), 2 deletions(-)
```

Upstream `2026.5..2026.5.1` is a single commit (`6fa4709 chore: bump version to 2026.5.1`) that only touches the two `__version__` strings. No freqtrade Python code was changed.

## Impact on fork-specific code

**None.** This release does not touch any of the files we customize:

- `_handle_external_close` / liquidation handling in `freqtradebot.py` ✅ untouched
- `fetch_liquidation_fills` in `exchange/hyperliquid.py` ✅ untouched
- `TrendRegularityFilter` pairlist plugin ✅ untouched
- Replay harness (`freqtrade/replay/`, `rpc/api_server/api_replay.py`) ✅ untouched
- Coordinator daemon ✅ untouched
- `/signal_summary` RPC ✅ untouched
- `backtest_lock_wallet` / position coordination ✅ untouched

**Merge difficulty: trivial.** Pure version bump, no conflicts, no fork-specific surface impacted.

## Post-merge

```bash
pip install -e .
```

No DB migration, no config change, no bot restart strategy needed beyond the usual.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HpMtd54GVzQD8GjKxjasFr)_