### PR TITLE
chore: align version to upstream 2026.5.1

### DIFF
--- a/freqtrade/__init__.py
+++ b/freqtrade/__init__.py
@@ -1,6 +1,6 @@
 """Freqtrade bot"""
 
-__version__ = "2026.5"
+__version__ = "2026.5.1"
 
 if "dev" in __version__:
     from pathlib import Path

--- a/ft_client/freqtrade_client/__init__.py
+++ b/ft_client/freqtrade_client/__init__.py
@@ -1,7 +1,7 @@
 from freqtrade_client.ft_rest_client import FtRestClient
 
 
-__version__ = "2026.5"
+__version__ = "2026.5.1"
 
 if "dev" in __version__:
     from pathlib import Path


### PR DESCRIPTION
## Upstream sync: 2026.5 → 2026.5.1

Upstream `freqtrade/freqtrade` released **2026.5.1** (2026-06-03). The full delta between the upstream `2026.5` and `2026.5.1` tags is **version-string-only**:

- `freqtrade/__init__.py`: `2026.5` → `2026.5.1`
- `ft_client/freqtrade_client/__init__.py`: `2026.5` → `2026.5.1`

No functional change — the fork's tree is already content-identical to upstream 2026.5.1. This PR just aligns the reported version so `freqtrade --version` matches the upstream baseline.

Fork tools untouched (external-close handler, Hyperliquid liquidation detection, TrendRegularityFilter, replay harness).
