### PR TITLE
chore: sync with upstream freqtrade 2026.6

### DIFF
--- a/freqtrade/__init__.py
+++ b/freqtrade/__init__.py
@@ -1,6 +1,6 @@
 """Freqtrade bot"""
 
-__version__ = "2026.5.1"
+__version__ = "2026.6"
 
 if "dev" in __version__:
     from pathlib import Path

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -1517,13 +1517,15 @@ class FreqtradeBot(LoggingMixin):
         # Fee is applied twice because we make a LIMIT_BUY and LIMIT_SELL
         fee = self.exchange.get_fee(symbol=pair, taker_or_maker="maker")
         base_currency = self.exchange.get_pair_base_currency(pair)
-        open_date = datetime.now(UTC)
-
-        funding_fees = self.exchange.get_funding_fees(
-            pair=pair,
-            amount=amount + trade.amount if trade else amount,
-            is_short=is_short,
-            open_date=trade.date_last_filled_utc if trade else open_date,
+        funding_fees = (
+            self.exchange.get_funding_fees(
+                pair=pair,
+                amount=trade.amount,
+                is_short=is_short,
+                open_date=trade.date_last_filled_utc,
+            )
+            if trade
+            else 0
         )
 
         # This is a new trade
@@ -1540,7 +1542,7 @@ class FreqtradeBot(LoggingMixin):
                 fee_close=fee,
                 open_rate=enter_limit_filled_price,
                 open_rate_requested=enter_limit_requested,
-                open_date=open_date,
+                open_date=datetime.now(UTC),
                 exchange=self.exchange.id,
                 strategy=self.strategy.get_strategy_name(),
                 enter_tag=enter_tag,

--- a/ft_client/freqtrade_client/__init__.py
+++ b/ft_client/freqtrade_client/__init__.py
@@ -1,7 +1,7 @@
 from freqtrade_client.ft_rest_client import FtRestClient
 
 
-__version__ = "2026.5.1"
+__version__ = "2026.6"
 
 if "dev" in __version__:
     from pathlib import Path


### PR DESCRIPTION
## Upstream release

`freqtrade/freqtrade` published **2026.6** on **2026-06-29**
(https://github.com/freqtrade/freqtrade/releases/tag/2026.6).

The fork was previously aligned to **2026.5.1**.

## What this PR does

- Bumps `freqtrade/__init__.py` and `ft_client/freqtrade_client/__init__.py`
  from `2026.5.1` → `2026.6` — same pattern as the prior `chore: align version
  to upstream 2026.5.1 (#19)` PR.
- Cherry-picks one clean upstream refactor into `freqtrade/freqtradebot.py`:
  the funding-fees lookup is now skipped entirely for brand-new trades (no
  more `open_date` local variable — inlined `datetime.now(UTC)` at the
  `Trade()` construction). Both slots line up with the fork's current file
  since the fork carries no local change in that region.

Nothing else in the 2026.5.1→2026.6 diff (71 upstream files, ~12k insertions,
~3.7k deletions) is included — see the impact analysis below.

## Impact on fork-specific code

Cleanly independent — **no conflict with our fork additions**:

- `_handle_external_close` / `_handle_liquidation` in `freqtradebot.py`
  (the upstream change is around line 1000; our handlers live around the
  cancel-stoploss path, unaffected).
- `exchange/hyperliquid.py` `fetch_liquidation_fills` — **not touched by
  the upstream diff**.
- `plugins/pairlist/TrendRegularityFilter.py` — **not touched**.
- `freqtrade/replay/` harness — **not touched**.
- `constants.py` registrations — **not touched**.

## Upstream changes NOT applied here (worth a manual review pass)

Non-conflicting drop-ins (would just widen coverage):

- `freqtrade/rpc/api_server/api_analysis.py` (**new file**, +234 lines) —
  extracts recursive / lookahead analysis endpoints to their own module.
- `docs/recursive-analysis.md`, `docs/lookahead-analysis.md`,
  `docs/backtesting.md` — doc updates.
- `.github/workflows/*.yml`, `.pre-commit-config.yaml`, `Dockerfile` — CI /
  build. Usually "accept theirs" per `CLAUDE.md`.

Files upstream refactored that we should re-check against our fork's
behaviour before pulling in:

- `freqtrade/rpc/api_server/api_backtest.py` (+107 lines) and
  `api_background_tasks.py` (+63 lines) — background job handling refactor.
  Our fork adds FleetView endpoints and DB-only trade rescale on top of the
  rpc/api_server tree — worth checking they still layer cleanly.
- `freqtrade/rpc/api_server/webserver.py` (+13) and `webserver_bgwork.py`
  (+38) — related to the background-job rework.
- `freqtrade/optimize/backtesting.py` (+138) and
  `freqtrade/optimize/analysis/{lookahead,recursive}*.py`.
- `freqtrade/strategy/interface.py` (+21).
- `freqtrade/data/metrics.py` (+22) — our fork now emits P-Value; check no
  overlap.
- `freqtrade/exchange/binance_leverage_tiers.json` (+13907 / -3733) —
  standard periodic refresh, safe to overwrite.
- Requirements bumps: `requirements*.txt` (ccxt 4.5.61, tqdm 4.68.3,
  sqlalchemy 2.0.51, ruff 0.15.18, etc.).

Recommendation: land this version-bump PR first (safe, matches the
existing pattern), then port the rpc/api_server refactor separately once
the fork's FleetView endpoints have been checked against upstream's new
background-task shape.

## Verification

- `python3 -c "import ast; ast.parse(open('freqtrade/freqtradebot.py').read())"` → OK
- `grep _handle_external_close freqtrade/freqtradebot.py` → still present
- `grep fetch_liquidation_fills freqtrade/exchange/hyperliquid.py` → still present

## Upstream release notes

https://github.com/freqtrade/freqtrade/releases/tag/2026.6


---
_Generated by [Claude Code](https://claude.ai/code/session_012JUxEJfavDehW14qwQnF4x)_