### PR TITLE
Corriger les prérequis et la présentation de Freqtrade France

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,9 +325,9 @@ Or visit [titouannwtt/frequi-ultimate](https://github.com/titouannwtt/frequi-ult
 
 **[Freqtrade France](https://buymeacoffee.com/freqtrade_france)** is the French-speaking community where Mouton (this fork's maintainer) publishes:
 
-- 📚 **Free tutorials** — Freqtrade basics, Hyperliquid setup, hyperopt, backtesting, walk-forward analysis (80 % of the content is free).
-- 💎 **Member tutorials** (9 € / month or 90 € / year) — PlateauSampler internals, custom hyperopt loss design, walk-forward CPCV deep dives, anti-overfitting playbook.
-- 🤖 **Ready-to-deploy strategies for members** — Live-tested, with reproducible backtests and live PnL.
+- **Free tutorials**: Freqtrade basics, Hyperliquid setup, hyperopt, backtesting, and walk-forward analysis.
+- **Member tutorials**: reproducible strategy studies, complete examples, and explanations of testing methods and their limitations. See [Freqtrade France](https://buymeacoffee.com/freqtrade_france) for the current membership offer and pricing. The public forks remain free to use.
+- **Strategy walkthroughs for members**: code and configuration, with the testing context and limitations described in each article.
 - 🎥 **Long-form YouTube** — [@freqtrade_france](https://www.youtube.com/@freqtrade_france).
 - 🐦 **Twitter** — [@MoutonCrypto](https://x.com/MoutonCrypto).
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -237,7 +237,7 @@ candle-boundary thundering herds.
 **Limitations.**
 
 - Single-host only (Unix socket, not networked).
-- Requires Python 3.10+ for the async daemon.
+- Requires Python 3.11+ as specified by the project’s `pyproject.toml`.
 - A daemon crash will force all bots to fall through to direct exchange calls; they will
   reconnect on the next cycle but may emit a burst of 429s in the meantime.
 
@@ -1333,7 +1333,7 @@ minimum-change path:
 8. **launch scripts**. Replace `freqtrade trade --config ...` with
    `./launch_bot.sh path/to/config.json` to get auto-restart, candle-boundary jitter and
    fleet stagger for free.
-9. **FreqUI**. Run `freqtrade deploy-ui` to fetch the [FreqUI Ultimate](https://github.com/titouannwtt/frequi-ultimate)
+9. **FreqUI**. Run `freqtrade install-ui` to fetch the [FreqUI Ultimate](https://github.com/titouannwtt/frequi-ultimate)
    build — the upstream FreqUI build does not know about the new endpoints
    (`/cache_status`, `/rate_metrics`, `/fleet/*`, `/volume_history`, `/signal_summary`,
    `/stratdev/*`) and will not render the corresponding widgets.
@@ -1347,8 +1347,7 @@ No DB migration is required; the SQLAlchemy schema is unchanged. The pool sizing
 
 - **Upstream base.** Tracks `freqtrade/freqtrade` `stable` branch. The fork sits ~58,400
   lines added and ~2,450 lines removed across 50 commits.
-- **Python.** Requires Python **3.10 or newer** (the async daemons and `cloudpickle`
-  pickle-by-value integration need it).
+- **Python.** Requires Python **3.11 or newer**, as declared in `pyproject.toml`.
 - **CCXT.** Pinned to a version supporting Hyperliquid spot and perpetuals (see the
   fork's `setup.py` / `pyproject.toml` for the exact pin).
 - **Hyperliquid.** First-class support, including liquidation detection


### PR DESCRIPTION
La documentation indique encore Python 3.10 et une commande `deploy-ui` absente du registre actuel. Elle annonce également un ancien tarif de Freqtrade France.

Cette modification aligne les prérequis sur `pyproject.toml` (Python 3.11 minimum), utilise `freqtrade install-ui` et renvoie vers l’offre BMC pour le tarif courant. La présentation distingue les forks publics gratuits des dossiers membres et retire les affirmations générales de validation live et de proportion gratuite.

Validation : comparaison avec le registre des commandes et `pyproject.toml`, `git diff --check`. Documentation uniquement, aucun changement de logique de trading.
